### PR TITLE
provide direct access to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ book.baked # => "2019-03-20T14:24:26.164476-05:00"
 book.url   # => "https://archive.cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a"
 ```
 
+To get all pages in a book:
+
+```ruby
+book.root_book_part.pages.count   # => 460
+```
+
 To dig deeper, get the `root_book_part` and then is `parts`
 
 ```ruby

--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -8,6 +8,9 @@ require_relative './v1/http_error'
 
 require_relative './v1/book'
 require_relative './v1/book_part'
+require_relative './v1/element'
+require_relative './v1/figure'
+require_relative './v1/paragraph'
 require_relative './v1/page'
 require_relative './v1/baked'
 

--- a/lib/openstax/cnx/v1/book.rb
+++ b/lib/openstax/cnx/v1/book.rb
@@ -1,7 +1,7 @@
 module OpenStax::Cnx::V1
   class Book
 
-    def initialize(id: nil, hash: nil, title: nil, tree: nil, root_book_part: nil)
+    def initialize(id:, hash: nil, title: nil, tree: nil, root_book_part: nil)
       @id             = id
       @hash           = hash
       @title          = title

--- a/lib/openstax/cnx/v1/book_part.rb
+++ b/lib/openstax/cnx/v1/book_part.rb
@@ -44,5 +44,11 @@ module OpenStax::Cnx::V1
       @is_chapter ||= parts.none? { |part| part.is_a?(self.class) }
     end
 
+    def pages
+      parts.map do |part|
+        part.is_a?(Page) ? part : part.pages
+      end.flatten
+    end
+
   end
 end

--- a/lib/openstax/cnx/v1/element.rb
+++ b/lib/openstax/cnx/v1/element.rb
@@ -1,0 +1,9 @@
+module OpenStax::Cnx::V1
+  class Element
+    attr_reader :node
+
+    def initialize(node:)
+      @node = node
+    end
+  end
+end

--- a/lib/openstax/cnx/v1/figure.rb
+++ b/lib/openstax/cnx/v1/figure.rb
@@ -1,0 +1,28 @@
+module OpenStax::Cnx::V1
+  class Figure < Element
+    MATCH_FIGURE = "//*[contains(@class, 'os-figure')]"
+
+    MATCH_FIGURE_CAPTION = ".//*[contains(@class, 'os-caption')]"
+    MATCH_FIGURE_ALT_TEXT = './/*[@data-alt]'
+
+    def initialize(node:)
+      super
+    end
+
+    def caption
+      node.xpath(MATCH_FIGURE_CAPTION).first.try(:text)
+    end
+
+    def alt_text
+      node.xpath(MATCH_FIGURE_ALT_TEXT).first.attr('data-alt')
+    end
+
+    def self.matcher
+      MATCH_FIGURE
+    end
+
+    def self.matches?(node)
+      node.matches?(MATCH_FIGURE)
+    end
+  end
+end

--- a/lib/openstax/cnx/v1/paragraph.rb
+++ b/lib/openstax/cnx/v1/paragraph.rb
@@ -1,0 +1,21 @@
+module OpenStax::Cnx::V1
+  class Paragraph < Element
+    MATCH_PARAGRAPH = '//p[@id]'
+
+    def initialize(node:)
+      super
+    end
+
+    def text
+      node.text
+    end
+
+    def self.matcher
+      MATCH_PARAGRAPH
+    end
+
+    def self.matches?(node)
+      node.matches?(MATCH_PARAGRAPH)
+    end
+  end
+end

--- a/spec/cassettes/OpenStax_Cnx_V1_Element/finds_the_given_elements_within_the_book.yml
+++ b/spec/cassettes/OpenStax_Cnx_V1_Element/finds_the_given_elements_within_the_book.yml
@@ -1,0 +1,2814 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://archive.cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=60, public
+      Content-Length:
+      - '132'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Tue, 09 Apr 2019 21:51:04 GMT
+      Etag:
+      - '"1B2M2Y8AsgTpgAmY7PhCfg"'
+      Location:
+      - https://archive.cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a@14.79
+      Server:
+      - waitress
+      X-Varnish-Status:
+      - cacheable - Cache-Control in backend response
+      X-Varnish-Backend:
+      - prod07_archive5
+      X-Varnish-Ttl:
+      - '60.000'
+      X-Varnish:
+      - '4589994'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish-v4
+      X-Varnish-Cache:
+      - MISS
+      Strict-Transport-Security:
+      - max-age=16000000
+    body:
+      encoding: UTF-8
+      string: |+
+        302 Found
+
+        The resource was found at /contents/031da8d3-b525-429c-80cf-6c8ed997733a@14.79; you should be redirected automatically.
+
+    http_version: 
+  recorded_at: Tue, 09 Apr 2019 21:51:04 GMT
+- request:
+    method: get
+    uri: https://archive.cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a@14.79
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=31536000, public
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Apr 2019 20:42:51 GMT
+      Etag:
+      - '"U+8QX9+uk4gdCqOIgu1/Sw"'
+      Expires:
+      - Tue, 07 Apr 2020 20:42:51 GMT
+      Link:
+      - <https://cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a/College-Physics>
+        ;rel="Canonical"
+      Server:
+      - waitress
+      X-Varnish-Status:
+      - cacheable - Cache-Control in backend response
+      X-Varnish-Backend:
+      - prod08_archive1
+      X-Varnish-Ttl:
+      - '31536000.000'
+      X-Varnish:
+      - 6025411 1639533
+      Age:
+      - '90493'
+      Via:
+      - 1.1 varnish-v4
+      X-Varnish-Cache:
+      - HIT
+      Accept-Ranges:
+      - bytes
+      Transfer-Encoding:
+      - chunked
+      Strict-Transport-Security:
+      - max-age=16000000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"googleAnalytics": ["UA-30227798-13", "UA-101537094-1"], "version":
+        "14.79", "submitlog": "resolving typo from erratum 8200 - CP", "abstract":
+        "<div xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:c=\"http://cnx.rice.edu/cnxml\"
+        xmlns:md=\"http://cnx.rice.edu/mdml\" xmlns:qml=\"http://cnx.rice.edu/qml/1.0\"
+        xmlns:mod=\"http://cnx.rice.edu/#moduleIds\" xmlns:bib=\"http://bibtexml.sf.net/\"
+        xmlns:data=\"http://dev.w3.org/html5/spec/#custom\"/>", "revised": "2019-03-20T19:23:09Z",
+        "printStyle": "physics", "roles": null, "keywords": [], "id": "031da8d3-b525-429c-80cf-6c8ed997733a",
+        "canonical": null, "title": "College Physics", "mediaType": "application/vnd.org.cnx.collection",
+        "canon_url": "https://cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a/College-Physics",
+        "subjects": [], "legacy_id": "col11406", "parentId": null, "resources": [{"media_type":
+        "text/xml", "id": "a4b61c80fad6967b133ae1f7cc4a5b8e8c1737c8", "filename":
+        "collection.xml"}], "publishers": [{"surname": "OpenStax College", "suffix":
+        "", "firstname": "", "title": "", "fullname": "OpenStax", "id": "OpenStaxCollege"},
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}], "parent": {"authors":
+        [], "shortId": null, "version": "", "id": null, "title": null}, "stateid":
+        1, "parentTitle": null, "shortId": "Ax2o07Ul", "authors": [{"surname": "OpenStax
+        College", "suffix": "", "firstname": "", "title": "", "fullname": "OpenStax",
+        "id": "OpenStaxCollege"}], "parentVersion": "", "legacy_version": "1.14",
+        "licensors": [{"surname": "University", "suffix": "", "firstname": "Rice",
+        "title": "", "fullname": "Rice University", "id": "OSCRiceUniversity"}], "language":
+        "en", "license": {"url": "http://creativecommons.org/licenses/by/4.0/", "code":
+        "by", "version": "4.0", "name": "Creative Commons Attribution License"}, "created":
+        "2012-01-23T07:03:30Z", "tree": {"shortId": "Ax2o07Ul@14.79", "id": "031da8d3-b525-429c-80cf-6c8ed997733a@14.79",
+        "contents": [{"shortId": "pFeekPiU@20", "id": "a4579e90-f894-4438-88c3-14772d3da9ff@20",
+        "title": "<span class=\"os-text\">Preface</span>"}, {"shortId": "5M2b30E7@14.1",
+        "id": "e4cd9bdf-413b-5adf-9a29-ce77cd9bf486@14.1", "contents": [{"shortId":
+        "HR_VN3f7@5", "id": "1d1fd537-77fb-4eac-8a8a-60bbaa747b6d@5", "title": "<span
+        class=\"os-text\">Introduction to Science and the Realm of Physics, Physical
+        Quantities, and Units</span>"}, {"shortId": "OSViBgOw@9", "id": "39256206-03b0-4396-abb6-75e6ee5e3c7b@9",
+        "title": "<span class=\"os-number\">1.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Physics: An Introduction</span>"}, {"shortId":
+        "EC6WBNqn@10", "id": "102e9604-daa7-4a09-9f9e-232251d1a4ee@10", "title": "<span
+        class=\"os-number\">1.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Physical
+        Quantities and Units</span>"}, {"shortId": "S7pqHKDm@11", "id": "4bba6a1c-a0e6-45c0-988c-0d5c23425670@11",
+        "title": "<span class=\"os-number\">1.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Accuracy, Precision, and Significant Figures</span>"},
+        {"shortId": "63W1MpHK@7", "id": "eb75b532-91ca-4c3d-b803-db329981914a@7",
+        "title": "<span class=\"os-number\">1.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Approximation</span>"}, {"shortId": "G09RIHWW@14.79",
+        "id": "1b4f5120-7596-5d0a-b169-e11f67fe608d@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "hjeLF3T0@14.79", "id": "86378b17-74f4-5176-bf44-2b61f344bb1c@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "yzLaWxV4@14.79",
+        "id": "cb32da5b-1578-550b-9de7-75c052f9c6de@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "x2DKb0fr@14.79", "id": "c760ca6f-47eb-505e-991b-e9e4d497c58c@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">1</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Introduction: The Nature of Science and Physics</span>"},
+        {"shortId": "qGgFmQBV@14.11", "id": "a8680599-0055-570c-bde6-23ddfe94a599@14.11",
+        "contents": [{"shortId": "4SMp5I1s@4", "id": "e12329e4-8d6c-49cf-aa45-6a05b26ebcba@4",
+        "title": "<span class=\"os-text\">Introduction to One-Dimensional Kinematics</span>"},
+        {"shortId": "_H3EiPTs@8", "id": "fc7dc488-f4ec-498c-b261-3b75eaa70aaa@8",
+        "title": "<span class=\"os-number\">2.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Displacement</span>"}, {"shortId": "gj9KHj0Q@4",
+        "id": "823f4a1e-3d10-44b6-a22e-8608f72c6eca@4", "title": "<span class=\"os-number\">2.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Vectors, Scalars, and
+        Coordinate Systems</span>"}, {"shortId": "FalnnAQi@7", "id": "15a9679c-0422-4712-9a6e-71bad4472a0c@7",
+        "title": "<span class=\"os-number\">2.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Time, Velocity, and Speed</span>"}, {"shortId":
+        "YCO4fVoo@9", "id": "6023b87d-5a28-4910-9e51-ee7fd11c98e1@9", "title": "<span
+        class=\"os-number\">2.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Acceleration</span>"},
+        {"shortId": "6iuyPE_O@14", "id": "ea2bb23c-4fce-4e9d-a46b-3754125da988@14",
+        "title": "<span class=\"os-number\">2.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Motion Equations for Constant Acceleration
+        in One Dimension</span>"}, {"shortId": "aNsXe6tc@4", "id": "68db177b-ab5c-48b9-8bcc-721e140fed8b@4",
+        "title": "<span class=\"os-number\">2.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Problem-Solving Basics for One-Dimensional
+        Kinematics</span>"}, {"shortId": "nkhtuBIO@10", "id": "9e486db8-120e-4507-b265-e5248007faba@10",
+        "title": "<span class=\"os-number\">2.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Falling Objects</span>"}, {"shortId": "7x6Qspwt@12",
+        "id": "ef1e90b2-9c2d-4d35-9faa-d1055b8d89db@12", "title": "<span class=\"os-number\">2.8</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Graphical Analysis of
+        One-Dimensional Motion</span>"}, {"shortId": "MmhCQLa9@14.79", "id": "32684240-b6bd-5826-ab04-7890e61f9a48@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "5br12hNa@14.79",
+        "id": "e5baf5da-135a-5440-9860-7a6e79983471@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "NatargdG@14.79", "id": "35ab5aae-0746-5c58-99c8-71fbb8304487@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "4dp857fB@14.79", "id": "e1da7ce7-b7c1-5bcb-b751-43ebaf42f9b9@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Kinematics</span>"},
+        {"shortId": "nDahozTR@14.5", "id": "9c36a1a3-34d1-596c-a0ca-fc51aa6c5006@14.5",
+        "contents": [{"shortId": "8wmg-WP7@5", "id": "f309a0f9-63fb-46ca-9585-d1e1dc96a142@5",
+        "title": "<span class=\"os-text\">Introduction to Two-Dimensional Kinematics</span>"},
+        {"shortId": "IdDiF9UP@8", "id": "21d0e217-d50f-4901-af75-905e738eb4c4@8",
+        "title": "<span class=\"os-number\">3.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Kinematics in Two Dimensions: An Introduction</span>"},
+        {"shortId": "S9i77L2i@11", "id": "4bd8bbec-bda2-412b-96f8-cc0b7ff5e794@11",
+        "title": "<span class=\"os-number\">3.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Vector Addition and Subtraction: Graphical
+        Methods</span>"}, {"shortId": "uXOb_dyd@15", "id": "b9739bfd-dc9d-4f0a-b037-dc22884d30f3@15",
+        "title": "<span class=\"os-number\">3.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Vector Addition and Subtraction: Analytical
+        Methods</span>"}, {"shortId": "aQYvRFbS@18", "id": "69062f44-56d2-4111-88ff-f599727c4ed1@18",
+        "title": "<span class=\"os-number\">3.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Projectile Motion</span>"}, {"shortId": "tk2gBy3y@21",
+        "id": "b64da007-2df2-4425-8f4b-e4d42ed423d9@21", "title": "<span class=\"os-number\">3.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Addition of Velocities</span>"},
+        {"shortId": "obKRQfyC@14.79", "id": "a1b29141-fc82-5eca-93dd-ee28d345b602@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "sO1L9OpL@14.79",
+        "id": "b0ed4bf4-ea4b-5d45-a3eb-4733324f0a6b@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "jeZKvFsc@14.79", "id": "8de64abc-5b1c-54d0-8620-382087e2abed@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "xQhHPEsR@14.79", "id": "c508473c-4b11-5dc2-8c6b-b6831123c59b@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Two-Dimensional
+        Kinematics</span>"}, {"shortId": "rYf9Eav5@14.4", "id": "ad87fd11-abf9-5710-91ce-8eb43f91ab95@14.4",
+        "contents": [{"shortId": "AvUqAiSE@7", "id": "02f52a02-2484-4ccb-bbd4-3c94edaa8e09@7",
+        "title": "<span class=\"os-text\">Introduction to Dynamics: Newton&#8217;s
+        Laws of Motion</span>"}, {"shortId": "3kOuFdH6@6", "id": "de43ae15-d1fa-4265-98f6-9820ff31a270@6",
+        "title": "<span class=\"os-number\">4.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Development of Force Concept</span>"}, {"shortId":
+        "5AhMTd-L@4", "id": "e4084c4d-df8b-43d3-af14-c2ea68d59f92@4", "title": "<span
+        class=\"os-number\">4.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Newton&#8217;s
+        First Law of Motion: Inertia</span>"}, {"shortId": "ivpbwI-1@12", "id": "8afa5bc0-8fb5-4d10-bddc-e626afef65ee@12",
+        "title": "<span class=\"os-number\">4.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Newton&#8217;s Second Law of Motion: Concept
+        of a System</span>"}, {"shortId": "1VEKi6Bu@10", "id": "d5510a8b-a06e-4634-a63f-2ec97b293af6@10",
+        "title": "<span class=\"os-number\">4.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Newton&#8217;s Third Law of Motion: Symmetry
+        in Forces</span>"}, {"shortId": "WlG1xRdW@13", "id": "5a51b5c5-1756-4d6c-b9be-84a9627ef003@13",
+        "title": "<span class=\"os-number\">4.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Normal, Tension, and Other Examples of Forces</span>"},
+        {"shortId": "mUgUzFLi@10", "id": "994814cc-52e2-4398-9a96-eae02025519e@10",
+        "title": "<span class=\"os-number\">4.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Problem-Solving Strategies</span>"}, {"shortId":
+        "w3JWHgjo@11", "id": "c372561e-08e8-41a1-ba72-9b4c00394c2d@11", "title": "<span
+        class=\"os-number\">4.7</span><span class=\"os-divider\"> </span><span class=\"os-text\">Further
+        Applications of Newton&#8217;s Laws of Motion</span>"}, {"shortId": "yHTM02xY@8",
+        "id": "c874ccd3-6c58-4104-918e-bded4f2c9ea4@8", "title": "<span class=\"os-number\">4.8</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Extended Topic: The Four
+        Basic Forces&#8212;An Introduction</span>"}, {"shortId": "5AKVP8J2@14.79",
+        "id": "e402953f-c276-57d9-9c9f-add336b1100e@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "xw1nQNRH@14.79", "id": "c70d6740-d447-5e65-92bb-9d0ed72a105d@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "0X98rucP@14.79",
+        "id": "d17f7cae-e70f-5765-a63d-254850930ced@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "9wTpbyJO@14.79", "id": "f704e96f-224e-5b39-a4ad-2c121af74b0c@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">4</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Dynamics: Force and Newton''s Laws of Motion</span>"}, {"shortId":
+        "gpxznQDQ@14.15", "id": "829c739d-00d0-5a44-aacf-e0e2da93c0b4@14.15", "contents":
+        [{"shortId": "lyM8iHiR@4", "id": "97233c88-7891-40c2-a908-a0dc22501b8c@4",
+        "title": "<span class=\"os-text\">Introduction: Further Applications of Newton&#8217;s
+        Laws</span>"}, {"shortId": "e_W1NEGW@15", "id": "7bf5b534-4196-4484-a777-a2f636a4cc11@15",
+        "title": "<span class=\"os-number\">5.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Friction</span>"}, {"shortId": "vjCEOfmx@16",
+        "id": "be308439-f9b1-40e7-b0a6-1631cbc7feaa@16", "title": "<span class=\"os-number\">5.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Drag Forces</span>"},
+        {"shortId": "8RrkL5Zm@19", "id": "f11ae42f-9666-4f36-93d9-0093f94df061@19",
+        "title": "<span class=\"os-number\">5.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Elasticity: Stress and Strain</span>"}, {"shortId":
+        "zXszO-05@14.79", "id": "cd7b333b-ed39-58a9-b374-dd6d58aa138d@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "FFJTJLdW@14.79",
+        "id": "14525324-b756-5dfb-a4da-761268ab1e04@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "95MPzy_w@14.79", "id": "f7930fcf-2ff0-51dc-889e-a955936cf9eb@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "SmfkwGjo@14.79", "id": "4a67e4c0-68e8-5ace-b520-833302424d96@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">5</span><span class=\"os-divider\"> </span><span class=\"os-text\">Further
+        Applications of Newton''s Laws: Friction, Drag, and Elasticity</span>"}, {"shortId":
+        "X_oKGwMa@14.6", "id": "5ffa0a1b-031a-5abe-a0c8-5e870be3c5bd@14.6", "contents":
+        [{"shortId": "PvXftgqN@4", "id": "3ef5dfb6-0a8d-433e-9c8f-b8c860a3903b@4",
+        "title": "<span class=\"os-text\">Introduction to Uniform Circular Motion
+        and Gravitation</span>"}, {"shortId": "RCFtg_5-@15", "id": "44216d83-fe7e-461d-a5f4-9f3e2ffa284b@15",
+        "title": "<span class=\"os-number\">6.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Rotation Angle and Angular Velocity</span>"},
+        {"shortId": "lsUL0z9f@15", "id": "96c50bd3-3f5f-42f6-8812-f3494e0f0888@15",
+        "title": "<span class=\"os-number\">6.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Centripetal Acceleration</span>"}, {"shortId":
+        "WEoP6FbQ@16", "id": "584a0fe8-56d0-497c-8f3d-8b0e3f0359a1@16", "title": "<span
+        class=\"os-number\">6.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Centripetal
+        Force</span>"}, {"shortId": "hswJtoDG@5", "id": "86cc09b6-80c6-43ad-b80f-187571f45107@5",
+        "title": "<span class=\"os-number\">6.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Fictitious Forces and Non-inertial Frames:
+        The Coriolis Force</span>"}, {"shortId": "3zzSixq6@11", "id": "df3cd28b-1aba-4abc-84d7-54224fbd2a78@11",
+        "title": "<span class=\"os-number\">6.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Newton&#8217;s Universal Law of Gravitation</span>"},
+        {"shortId": "SkQH7Qlp@10", "id": "4a4407ed-0969-4018-806f-6ea728d6efb4@10",
+        "title": "<span class=\"os-number\">6.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Satellites and Kepler&#8217;s Laws: An Argument
+        for Simplicity</span>"}, {"shortId": "0JVnVG3m@14.79", "id": "d0956754-6de6-5570-a745-7ba218d90d2f@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "7SBat0Gl@14.79",
+        "id": "ed205ab7-41a5-5c38-9444-8e97d9bf30b2@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "u0WM1a43@14.79", "id": "bb458cd5-ae37-53d8-85d1-be9b432ec13c@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "Z3NvTYdP@14.79", "id": "67736f4d-874f-516b-8aa9-0ddcb30dd621@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">6</span><span class=\"os-divider\"> </span><span class=\"os-text\">Uniform
+        Circular Motion and Gravitation</span>"}, {"shortId": "5BMhhrF9@14.11", "id":
+        "e4132186-b17d-5a44-bffa-8a8ef4a2bc7b@14.11", "contents": [{"shortId": "ZDtuSt4h@4",
+        "id": "643b6e4a-de21-4a14-a677-b0d4c5ddb2d5@4", "title": "<span class=\"os-text\">Introduction
+        to Work, Energy, and Energy Resources</span>"}, {"shortId": "NkooLWJ4@10",
+        "id": "364a282d-6278-46df-83c1-1df19d673b51@10", "title": "<span class=\"os-number\">7.1</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Work: The Scientific
+        Definition</span>"}, {"shortId": "P_-6tVsN@8", "id": "3fffbab5-5b0d-4622-be83-eb65111f9c3e@8",
+        "title": "<span class=\"os-number\">7.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Kinetic Energy and the Work-Energy Theorem</span>"},
+        {"shortId": "RTxYH8A6@11", "id": "453c581f-c03a-4594-b17f-28f97fa6d39e@11",
+        "title": "<span class=\"os-number\">7.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Gravitational Potential Energy</span>"}, {"shortId":
+        "MvpfSmd_@8", "id": "32fa5f4a-677f-455a-b767-8711ee4bf7a8@8", "title": "<span
+        class=\"os-number\">7.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Conservative
+        Forces and Potential Energy</span>"}, {"shortId": "CS_6KKGe@11", "id": "092ffa28-a19e-4bd7-939a-1dfef1ee2a1a@11",
+        "title": "<span class=\"os-number\">7.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Nonconservative Forces</span>"}, {"shortId":
+        "xa2wEvur@11", "id": "c5adb012-fbab-41a7-b5b2-4644984097fc@11", "title": "<span
+        class=\"os-number\">7.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">Conservation
+        of Energy</span>"}, {"shortId": "yCUV7gLv@7", "id": "c82515ee-02ef-4e15-9b4f-52e67617359c@7",
+        "title": "<span class=\"os-number\">7.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Power</span>"}, {"shortId": "bGKCa-M8@8", "id":
+        "6c62826b-e33c-446f-b8d0-10a4b6156549@8", "title": "<span class=\"os-number\">7.8</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Work, Energy, and Power
+        in Humans</span>"}, {"shortId": "pLfg7L3t@7", "id": "a4b7e0ec-bded-45de-8016-416aaaa8286b@7",
+        "title": "<span class=\"os-number\">7.9</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">World Energy Use</span>"}, {"shortId": "tudXLv92@14.79",
+        "id": "b6e7572e-ff76-5569-b09c-6b1c2df69003@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "easRBfXs@14.79", "id": "79ab1105-f5ec-5823-b09c-6a8a0489e039@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "bIyGAHu0@14.79",
+        "id": "6c8c8600-7bb4-5e06-a9e2-6fa788c0967e@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "L7ryMjL_@14.79", "id": "2fbaf232-32ff-50fd-9e05-e6e27a9e285f@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">7</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Work, Energy, and Energy Resources</span>"}, {"shortId":
+        "RwwY8S3T@14.11", "id": "470c18f1-2dd3-537c-a88c-9c2e32b988fe@14.11", "contents":
+        [{"shortId": "Zyl5ofSl@7", "id": "672979a1-f4a5-41bc-9d93-c5d34df0587f@7",
+        "title": "<span class=\"os-text\">Introduction to Linear Momentum and Collisions</span>"},
+        {"shortId": "k9NLU1T7@5", "id": "93d34b53-54fb-4056-b8a5-ce22ec22321f@5",
+        "title": "<span class=\"os-number\">8.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Linear Momentum and Force</span>"}, {"shortId":
+        "CzoOFr0x@9", "id": "0b3a0e16-bd31-4349-af57-dcdacbfab7ce@9", "title": "<span
+        class=\"os-number\">8.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Impulse</span>"},
+        {"shortId": "AHEj4J20@5", "id": "007123e0-9db4-48bf-bd90-8976ff53a920@5",
+        "title": "<span class=\"os-number\">8.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Conservation of Momentum</span>"}, {"shortId":
+        "6dH1OHNo@8", "id": "e9d1f538-7368-4465-ab33-94ba72cd1872@8", "title": "<span
+        class=\"os-number\">8.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Elastic
+        Collisions in One Dimension</span>"}, {"shortId": "n0ys5Rlj@13", "id": "9f4cace5-1963-43b0-bfca-2ab221ed2c7a@13",
+        "title": "<span class=\"os-number\">8.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Inelastic Collisions in One Dimension</span>"},
+        {"shortId": "ygtr8OJJ@9", "id": "ca0b6bf0-e249-45a5-aa43-3088b4f66739@9",
+        "title": "<span class=\"os-number\">8.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Collisions of Point Masses in Two Dimensions</span>"},
+        {"shortId": "XqZk9PMg@12", "id": "5ea664f4-f320-4873-93c7-0dc838e9c9ae@12",
+        "title": "<span class=\"os-number\">8.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Introduction to Rocket Propulsion</span>"},
+        {"shortId": "aBdyTzMV@14.79", "id": "6817724f-3315-51b7-9b13-e8c01ab891d9@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "lt0QYLuL@14.79",
+        "id": "96dd1060-bb8b-5386-90a7-220e55c353df@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "nLReo4q-@14.79", "id": "9cb45ea3-8abe-52c6-8376-977aa142f47b@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "uV6pWDSS@14.79", "id": "b95ea958-3492-5bdb-8cb2-67ad60510612@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">8</span><span class=\"os-divider\"> </span><span class=\"os-text\">Linear
+        Momentum and Collisions</span>"}, {"shortId": "kmWg31yE@14.37", "id": "9265a0df-5c84-5e85-bbaa-107d7e7f06a2@14.37",
+        "contents": [{"shortId": "Vpx1oNLV@7", "id": "569c75a0-d2d5-4f12-a075-6ac5736617e9@7",
+        "title": "<span class=\"os-text\">Introduction to Statics and Torque</span>"},
+        {"shortId": "7h_yVSwE@9", "id": "ee1ff255-2c04-4a6d-aa23-6d981b02ea48@9",
+        "title": "<span class=\"os-number\">9.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The First Condition for Equilibrium</span>"},
+        {"shortId": "EarCWlUd@10", "id": "11aac25a-551d-4c47-8524-1a98414470b3@10",
+        "title": "<span class=\"os-number\">9.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Second Condition for Equilibrium</span>"},
+        {"shortId": "voQvsfn8@11", "id": "be842fb1-f9fc-48db-919b-b197c7a6ee8c@11",
+        "title": "<span class=\"os-number\">9.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Stability</span>"}, {"shortId": "08MLcTtn@11",
+        "id": "d3c30b71-3b67-41b1-9e1e-5accd05f159d@11", "title": "<span class=\"os-number\">9.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Applications of Statics,
+        Including Problem-Solving Strategies</span>"}, {"shortId": "vbDWbbny@8", "id":
+        "bdb0d66d-b9f2-4143-80f8-f07a066bb6ff@8", "title": "<span class=\"os-number\">9.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Simple Machines</span>"},
+        {"shortId": "1wOFPGOC@11", "id": "d703853c-6382-4035-8d6a-dcbca00a15ca@11",
+        "title": "<span class=\"os-number\">9.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Forces and Torques in Muscles and Joints</span>"},
+        {"shortId": "QDRIVeHP@14.79", "id": "40344855-e1cf-5ce2-afdf-0a055ea7f347@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "SrFiSz5e@14.79",
+        "id": "4ab1624b-3e5e-553f-a635-230d47479e64@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "XmzftU8Z@14.79", "id": "5e6cdfb5-4f19-52d8-acc1-2f31f930caa9@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "KZD39Ocy@14.79", "id": "2990f7f4-e732-5278-b20c-21287a860df9@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">9</span><span class=\"os-divider\"> </span><span class=\"os-text\">Statics
+        and Torque</span>"}, {"shortId": "NiumZZHe@14.12", "id": "362ba665-91de-5873-b0e6-5f8574c53305@14.12",
+        "contents": [{"shortId": "iYslgv4G@6", "id": "898b2582-fe06-477a-922c-3060f72613a4@6",
+        "title": "<span class=\"os-text\">Introduction to Rotational Motion and Angular
+        Momentum</span>"}, {"shortId": "CUhSoH-J@10", "id": "094852a0-7f89-4a97-b8ea-5659133fd740@10",
+        "title": "<span class=\"os-number\">10.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Angular Acceleration</span>"}, {"shortId":
+        "HwZ-qGy-@7", "id": "1f067ea8-6cbe-463b-b672-8cd39ccfb360@7", "title": "<span
+        class=\"os-number\">10.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Kinematics
+        of Rotational Motion</span>"}, {"shortId": "21n2VucI@10", "id": "db59f656-e708-4094-a742-1e5560fe97c9@10",
+        "title": "<span class=\"os-number\">10.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Dynamics of Rotational Motion: Rotational Inertia</span>"},
+        {"shortId": "syi1onnq@12", "id": "b328b5a2-79ea-4faa-9674-8d62df2f288e@12",
+        "title": "<span class=\"os-number\">10.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Rotational Kinetic Energy: Work and Energy
+        Revisited</span>"}, {"shortId": "feW-kwnh@9", "id": "7de5be93-09e1-4ab6-8282-bec00a3e9f3d@9",
+        "title": "<span class=\"os-number\">10.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Angular Momentum and Its Conservation</span>"},
+        {"shortId": "m0l_Rsl5@7", "id": "9b497f46-c979-43cd-a431-be855ec76d47@7",
+        "title": "<span class=\"os-number\">10.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Collisions of Extended Bodies in Two Dimensions</span>"},
+        {"shortId": "BB7_sFuI@6", "id": "041effb0-5b88-46e0-895e-4b9f804607df@6",
+        "title": "<span class=\"os-number\">10.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Gyroscopic Effects: Vector Aspects of Angular
+        Momentum</span>"}, {"shortId": "1X91W_jx@14.79", "id": "d57f755b-f8f1-553d-bc6b-39542448be65@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "M_qlK4M9@14.79",
+        "id": "33faa52b-833d-5856-9280-cb71c18b615b@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "jzvrUrCb@14.79", "id": "8f3beb52-b09b-5719-af7b-213c9428914b@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "impebxE7@14.79", "id": "8a6a5e6f-113b-5fb1-920c-a9834cf48edd@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">10</span><span class=\"os-divider\"> </span><span class=\"os-text\">Rotational
+        Motion and Angular Momentum</span>"}, {"shortId": "7l2kPe--@14.2", "id": "ee5da43d-efbe-5886-a636-94d45dfe0df3@14.2",
+        "contents": [{"shortId": "g5mux1l3@7", "id": "8399aec7-5977-427c-83f6-59b0c2bae7e2@7",
+        "title": "<span class=\"os-text\">Introduction to Fluid Statics</span>"},
+        {"shortId": "u5gl4Qku@8", "id": "bb9825e1-092e-4c11-b5c8-265d4317ae34@8",
+        "title": "<span class=\"os-number\">11.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">What Is a Fluid?</span>"}, {"shortId": "8TdYj7ep@5",
+        "id": "f137588f-b7a9-44cd-8df1-1818df41d568@5", "title": "<span class=\"os-number\">11.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Density</span>"}, {"shortId":
+        "9xO9qWf3@9", "id": "f713bda9-67f7-49c9-9d9d-ca2e34a202a5@9", "title": "<span
+        class=\"os-number\">11.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Pressure</span>"},
+        {"shortId": "XwsODugl@5", "id": "5f0b0e0e-e825-4aeb-9c8e-1f64a6942233@5",
+        "title": "<span class=\"os-number\">11.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Variation of Pressure with Depth in a Fluid</span>"},
+        {"shortId": "6YDWNV9M@5", "id": "e980d635-5f4c-4857-9b29-c51ee0760909@5",
+        "title": "<span class=\"os-number\">11.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Pascal&#8217;s Principle</span>"}, {"shortId":
+        "oI_2Ez1A@8", "id": "a08ff613-3d40-4b34-8416-782febd89317@8", "title": "<span
+        class=\"os-number\">11.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">Gauge
+        Pressure, Absolute Pressure, and Pressure Measurement</span>"}, {"shortId":
+        "geIysFJF@12", "id": "81e232b0-5245-4d19-b28d-31c1cf1624e0@12", "title": "<span
+        class=\"os-number\">11.7</span><span class=\"os-divider\"> </span><span class=\"os-text\">Archimedes&#8217;
+        Principle</span>"}, {"shortId": "7vEquViP@9", "id": "eef12ab9-588f-4922-9314-ac1cb25831f5@9",
+        "title": "<span class=\"os-number\">11.8</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Cohesion and Adhesion in Liquids: Surface Tension
+        and Capillary Action</span>"}, {"shortId": "FW9veKTn@7", "id": "156f6f78-a4e7-454d-a032-9b14f4223cd9@7",
+        "title": "<span class=\"os-number\">11.9</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Pressures in the Body</span>"}, {"shortId":
+        "aYy3j6e8@14.79", "id": "698cb78f-a7bc-56e0-8699-063523415b42@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "zYDKcQf-@14.79",
+        "id": "cd80ca71-07fe-5dfc-8aa4-b8af451ec0a4@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "VCtQw-wK@14.79", "id": "542b50c3-ec0a-5bed-8a5b-eb4dc0642608@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "TlxYFv8M@14.79", "id": "4e5c5816-ff0c-514c-8be6-7faaa02749f1@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">11</span><span class=\"os-divider\"> </span><span class=\"os-text\">Fluid
+        Statics</span>"}, {"shortId": "9x8JAKCR@14.1", "id": "f71f0900-a091-51d6-8f2c-711517dfeee9@14.1",
+        "contents": [{"shortId": "Y3wj6FHT@5", "id": "637c23e8-51d3-4a3f-bd5f-5b7de7efca23@5",
+        "title": "<span class=\"os-text\">Introduction to Fluid Dynamics and Its Biological
+        and Medical Applications</span>"}, {"shortId": "g9Jw9bqg@8", "id": "83d270f5-baa0-4bf9-a22a-539025b29180@8",
+        "title": "<span class=\"os-number\">12.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Flow Rate and Its Relation to Velocity</span>"},
+        {"shortId": "DIrGbKQb@9", "id": "0c8ac66c-a41b-4861-8fc6-e9633182091f@9",
+        "title": "<span class=\"os-number\">12.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Bernoulli&#8217;s Equation</span>"}, {"shortId":
+        "_P4p4D_P@6", "id": "fcfe29e0-3fcf-4f9a-a269-51b8bb710f2f@6", "title": "<span
+        class=\"os-number\">12.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">The
+        Most General Applications of Bernoulli&#8217;s Equation</span>"}, {"shortId":
+        "pCk_wk3i@7", "id": "a4293fc2-4de2-4506-b890-a7abdeb70c16@7", "title": "<span
+        class=\"os-number\">12.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Viscosity
+        and Laminar Flow; Poiseuille&#8217;s Law</span>"}, {"shortId": "biq2eyw4@9",
+        "id": "6e2ab67b-2c38-4d06-8ec7-648e083b628e@9", "title": "<span class=\"os-number\">12.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">The Onset of Turbulence</span>"},
+        {"shortId": "E1HJQcnG@7", "id": "1351c941-c9c6-416a-be45-12c6a072301e@7",
+        "title": "<span class=\"os-number\">12.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Motion of an Object in a Viscous Fluid</span>"},
+        {"shortId": "0d7JkTgM@6", "id": "d1dec991-380c-4534-a394-14e5a7729872@6",
+        "title": "<span class=\"os-number\">12.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Molecular Transport Phenomena: Diffusion, Osmosis,
+        and Related Processes</span>"}, {"shortId": "HL3DuKO0@14.79", "id": "1cbdc3b8-a3b4-5301-b0ef-1a9d0cc8be1d@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "wIX1fNta@14.79",
+        "id": "c085f57c-db5a-5cff-a65e-d10efb84f1f3@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "lz0DiSM-@14.79", "id": "973d0389-233e-5cdf-9b7e-6342e697be15@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "kff1rYvc@14.79", "id": "91f7f5ad-8bdc-5a79-ab6b-d9b2433c237f@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">12</span><span class=\"os-divider\"> </span><span class=\"os-text\">Fluid
+        Dynamics and Its Biological and Medical Applications</span>"}, {"shortId":
+        "-EtAfjYs@14.7", "id": "f84b407e-362c-5465-af92-3242a84e9133@14.7", "contents":
+        [{"shortId": "YFt95DxR@5", "id": "605b7de4-3c51-4624-96f2-c512950af889@5",
+        "title": "<span class=\"os-text\">Introduction to Temperature, Kinetic Theory,
+        and the Gas Laws</span>"}, {"shortId": "2ou0Jg2y@6", "id": "da8bb426-0db2-44a0-8a48-a62c2acf4482@6",
+        "title": "<span class=\"os-number\">13.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Temperature</span>"}, {"shortId": "C20NI-lv@7",
+        "id": "0b6d0d23-e96f-4f34-8051-643361f8c7c7@7", "title": "<span class=\"os-number\">13.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Thermal Expansion of
+        Solids and Liquids</span>"}, {"shortId": "j0ywdp9f@7", "id": "8f4cb076-9f5f-4a21-966e-079d768f7a98@7",
+        "title": "<span class=\"os-number\">13.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Ideal Gas Law</span>"}, {"shortId": "uwkQCfIf@9",
+        "id": "bb091009-f21f-47a2-954b-3b79871974b3@9", "title": "<span class=\"os-number\">13.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Kinetic Theory: Atomic
+        and Molecular Explanation of Pressure and Temperature</span>"}, {"shortId":
+        "oSrOCkyf@9", "id": "a12ace0a-4c9f-4297-bc76-1c3b77d4d9ce@9", "title": "<span
+        class=\"os-number\">13.5</span><span class=\"os-divider\"> </span><span class=\"os-text\">Phase
+        Changes</span>"}, {"shortId": "AwNH6fEo@10", "id": "030347e9-f128-486f-a779-019ac474ff90@10",
+        "title": "<span class=\"os-number\">13.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Humidity, Evaporation, and Boiling</span>"},
+        {"shortId": "66whEi9s@14.79", "id": "ebac2112-2f6c-5fdd-b80a-736fcc21b09f@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "WI5QMsNm@14.79",
+        "id": "588e5032-c366-56fd-8361-4f37bfdf4f85@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "05gOEZHv@14.79", "id": "d3980e11-91ef-5ca4-8b9b-9f54013c6fae@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "z0hAgY17@14.79", "id": "cf484081-8d7b-58ab-b660-88135474b5d0@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">13</span><span class=\"os-divider\"> </span><span class=\"os-text\">Temperature,
+        Kinetic Theory, and the Gas Laws</span>"}, {"shortId": "JGPGKi9R@14.4", "id":
+        "2463c62a-2f51-517d-baef-6072ccf811a5@14.4", "contents": [{"shortId": "eJLN3YM-@6",
+        "id": "7892cddd-833e-42b8-bcaa-a1e94fb9eb9c@6", "title": "<span class=\"os-text\">Introduction
+        to Heat and Heat Transfer Methods</span>"}, {"shortId": "UXXmpvhL@6", "id":
+        "5175e6a6-f84b-4955-9840-c9f07e8e7436@6", "title": "<span class=\"os-number\">14.1</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Heat</span>"}, {"shortId":
+        "XA0Vd8Dc@9", "id": "5c0d1577-c0dc-43c0-9c49-aca8e01227ff@9", "title": "<span
+        class=\"os-number\">14.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Temperature
+        Change and Heat Capacity</span>"}, {"shortId": "Xyta70lI@11", "id": "5f2b5aef-4948-488f-8ff9-839478a6d6cf@11",
+        "title": "<span class=\"os-number\">14.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Phase Change and Latent Heat</span>"}, {"shortId":
+        "Q1FnCAex@6", "id": "43516708-07b1-48f9-8314-7460d6ce7bbb@6", "title": "<span
+        class=\"os-number\">14.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Heat
+        Transfer Methods</span>"}, {"shortId": "p77aQy86@10", "id": "a7beda43-2f3a-4d12-adfe-2e19c20b5e14@10",
+        "title": "<span class=\"os-number\">14.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Conduction</span>"}, {"shortId": "q8K8ySAD@8",
+        "id": "abc2bcc9-2003-4d36-971a-05781d15e99c@8", "title": "<span class=\"os-number\">14.6</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Convection</span>"},
+        {"shortId": "lJrnhqMI@10", "id": "949ae786-a308-4f86-be47-32358239ac40@10",
+        "title": "<span class=\"os-number\">14.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Radiation</span>"}, {"shortId": "aNWDzLmW@14.79",
+        "id": "68d583cc-b996-59a4-b92c-c61d478a8321@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "jymiWZAl@14.79", "id": "8f29a259-9025-5b0c-9649-7ff40bcafa40@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "MzVyAHhb@14.79",
+        "id": "33357200-785b-5147-9f30-a63362eb1eb8@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "go3GJ9dm@14.79", "id": "828dc627-d766-5a18-a4af-ac82b91fc8a3@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">14</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Heat and Heat Transfer Methods</span>"}, {"shortId": "t8RuQeV0@14.2",
+        "id": "b7c46e41-e574-5d17-b7eb-41bfa7cf88ce@14.2", "contents": [{"shortId":
+        "0m3DW_eU@6", "id": "d26dc35b-f794-427e-b39d-f4b5496fd118@6", "title": "<span
+        class=\"os-text\">Introduction to Thermodynamics</span>"}, {"shortId": "-xG0g7hf@9",
+        "id": "fb11b483-b85f-4cda-bec7-4dfd136dba60@9", "title": "<span class=\"os-number\">15.1</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">The First Law of Thermodynamics</span>"},
+        {"shortId": "xUMJ21t4@11", "id": "c54309db-5b78-4a77-9e4f-61adc778cb50@11",
+        "title": "<span class=\"os-number\">15.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The First Law of Thermodynamics and Some Simple
+        Processes</span>"}, {"shortId": "_RSOYYkJ@6", "id": "fd148e61-8909-46dc-be6f-4beeec06fec1@6",
+        "title": "<span class=\"os-number\">15.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Introduction to the Second Law of Thermodynamics:
+        Heat Engines and Their Efficiency</span>"}, {"shortId": "L46Suvak@6", "id":
+        "2f8e92ba-f6a4-4fae-9228-64fd959894d8@6", "title": "<span class=\"os-number\">15.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Carnot&#8217;s Perfect
+        Heat Engine: The Second Law of Thermodynamics Restated</span>"}, {"shortId":
+        "LzKO_Zdu@5", "id": "2f328efd-976e-4d46-9a43-abbcb8f8bbb1@5", "title": "<span
+        class=\"os-number\">15.5</span><span class=\"os-divider\"> </span><span class=\"os-text\">Applications
+        of Thermodynamics: Heat Pumps and Refrigerators</span>"}, {"shortId": "FaUBlJzx@12",
+        "id": "15a50194-9cf1-4848-8d68-dcce5788433e@12", "title": "<span class=\"os-number\">15.6</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Entropy and the Second
+        Law of Thermodynamics: Disorder and the Unavailability of Energy</span>"},
+        {"shortId": "2bloGtXY@6", "id": "d9b9681a-d5d8-4640-91bd-68268ccebf33@6",
+        "title": "<span class=\"os-number\">15.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Statistical Interpretation of Entropy and the
+        Second Law of Thermodynamics: The Underlying Explanation</span>"}, {"shortId":
+        "kjlPmO7r@14.79", "id": "92394f98-eeeb-5252-97eb-170d6ca76f78@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "InJyX5-9@14.79",
+        "id": "2272725f-9fbd-55cb-86c1-a58e11ac6e26@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "6B7u0fx1@14.79", "id": "e81eeed1-fc75-5c1b-ab8d-376328ef5603@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "K6VvWLoL@14.79", "id": "2ba56f58-ba0b-58cd-b368-bc166a569c12@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">15</span><span class=\"os-divider\"> </span><span class=\"os-text\">Thermodynamics</span>"},
+        {"shortId": "a_M-5687@14.4", "id": "6bf33ee7-af3b-5344-9a6c-3a28213ef30b@14.4",
+        "contents": [{"shortId": "Ix23ckjc@5", "id": "231db772-48dc-4a7c-bf35-eee3868eef69@5",
+        "title": "<span class=\"os-text\">Introduction to Oscillatory Motion and Waves</span>"},
+        {"shortId": "p8ISYDz5@9", "id": "a7c21260-3cf9-49cc-91f7-b631fa0c5d42@9",
+        "title": "<span class=\"os-number\">16.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Hooke&#8217;s Law: Stress and Strain Revisited</span>"},
+        {"shortId": "M1dWaYY4@6", "id": "33575669-8638-45a8-b8cf-17b64b35e071@6",
+        "title": "<span class=\"os-number\">16.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Period and Frequency in Oscillations</span>"},
+        {"shortId": "Kh_9SAO6@11", "id": "2a1ffd48-03ba-45d0-94bc-8afc38ebad19@11",
+        "title": "<span class=\"os-number\">16.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Simple Harmonic Motion: A Special Periodic
+        Motion</span>"}, {"shortId": "G4HHkiOf@9", "id": "1b81c792-239f-4107-9e94-37233e6f7e92@9",
+        "title": "<span class=\"os-number\">16.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Simple Pendulum</span>"}, {"shortId": "hbjNY-J8@9",
+        "id": "85b8cd63-e27c-456e-a04f-2312e3966efc@9", "title": "<span class=\"os-number\">16.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Energy and the Simple
+        Harmonic Oscillator</span>"}, {"shortId": "zQU08uz7@7", "id": "cd0534f2-ecfb-4784-8db6-c93aad2f8e36@7",
+        "title": "<span class=\"os-number\">16.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Uniform Circular Motion and Simple Harmonic
+        Motion</span>"}, {"shortId": "Zn-0Bj3n@9", "id": "667fb406-3de7-4ecd-93f5-aedd38351567@9",
+        "title": "<span class=\"os-number\">16.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Damped Harmonic Motion</span>"}, {"shortId":
+        "UdzQXdaa@7", "id": "51dcd05d-d69a-4107-8193-f3e95cd96ef1@7", "title": "<span
+        class=\"os-number\">16.8</span><span class=\"os-divider\"> </span><span class=\"os-text\">Forced
+        Oscillations and Resonance</span>"}, {"shortId": "6mEKtWaY@10", "id": "ea610ab5-6698-4f16-b4f1-6a210247701f@10",
+        "title": "<span class=\"os-number\">16.9</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Waves</span>"}, {"shortId": "8bWwAN4H@8", "id":
+        "f1b5b000-de07-4a0e-9078-4620a3bc7c34@8", "title": "<span class=\"os-number\">16.10</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Superposition and Interference</span>"},
+        {"shortId": "wc-nPos4@9", "id": "c1cfa73e-8b38-431c-af6e-ecba8c1fee70@9",
+        "title": "<span class=\"os-number\">16.11</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Energy in Waves: Intensity</span>"}, {"shortId":
+        "ldEnLVYO@14.79", "id": "95d1272d-560e-5cc9-924d-df73b3980604@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "8x11nESu@14.79",
+        "id": "f31d759c-44ae-58ce-9ea6-436a369e62cf@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "C77wUtiJ@14.79", "id": "0bbef052-d889-52e3-b227-f616a8632d32@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "395-0S2N@14.79", "id": "dfde7ed1-2d8d-51b1-b7de-d52644387336@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">16</span><span class=\"os-divider\"> </span><span class=\"os-text\">Oscillatory
+        Motion and Waves</span>"}, {"shortId": "eQdt8RFU@14.1", "id": "79076df1-1154-5917-9cfa-a2675debffcd@14.1",
+        "contents": [{"shortId": "N3j76YvP@5", "id": "3778fbe9-8bcf-473c-a614-549073cf27e2@5",
+        "title": "<span class=\"os-text\">Introduction to the Physics of Hearing</span>"},
+        {"shortId": "nSDxAoyX@7", "id": "9d20f102-8c97-4cd1-a16e-b7d5dce1a076@7",
+        "title": "<span class=\"os-number\">17.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Sound</span>"}, {"shortId": "yEAzTwGJ@6", "id":
+        "c840334f-0189-48ae-80db-a9afafa72b73@6", "title": "<span class=\"os-number\">17.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Speed of Sound, Frequency,
+        and Wavelength</span>"}, {"shortId": "YgXzJxtu@5", "id": "6205f327-1b6e-4bbe-a4b2-f6d0b5df29d5@5",
+        "title": "<span class=\"os-number\">17.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Sound Intensity and Sound Level</span>"}, {"shortId":
+        "N4kemM6L@4", "id": "37891e98-ce8b-4a6a-8e5e-d9889126d53a@4", "title": "<span
+        class=\"os-number\">17.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Doppler
+        Effect and Sonic Booms</span>"}, {"shortId": "5MG__z6R@8", "id": "e4c1bfff-3e91-4254-a5f7-0e4582a0541f@8",
+        "title": "<span class=\"os-number\">17.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Sound Interference and Resonance: Standing
+        Waves in Air Columns</span>"}, {"shortId": "zvDqPACq@5", "id": "cef0ea3c-00aa-4755-a6e5-92ffec01dc60@5",
+        "title": "<span class=\"os-number\">17.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Hearing</span>"}, {"shortId": "HNJRVnsT@10",
+        "id": "1cd25156-7b13-4767-a14d-71ad2ce0352d@10", "title": "<span class=\"os-number\">17.7</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Ultrasound</span>"},
+        {"shortId": "SjX-ZZMR@14.79", "id": "4a35fe65-9311-5adf-802a-4c5b79d314ae@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "Rn5gqYw_@14.79",
+        "id": "467e60a9-8c3f-5b78-a1bc-f09077a2262c@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "kE9V7r5E@14.79", "id": "904f55ee-be44-5456-92ae-42ee6791d155@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "1tfoA0-M@14.79", "id": "d6d7e803-4f8c-582e-a2f9-9bbacb6de3c2@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">17</span><span class=\"os-divider\"> </span><span class=\"os-text\">Physics
+        of Hearing</span>"}, {"shortId": "rH1-lorz@14.2", "id": "ac7d7e96-8af3-5990-aabc-1706f7efa9aa@14.2",
+        "contents": [{"shortId": "mbRj4L0x@5", "id": "99b463e0-bd31-4f32-afc6-fdb3d363db69@5",
+        "title": "<span class=\"os-text\">Introduction to Electric Charge and Electric
+        Field</span>"}, {"shortId": "u33De1px@9", "id": "bb7dc37b-5a71-4f4d-b83f-524e0f1b3c74@9",
+        "title": "<span class=\"os-number\">18.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Static Electricity and Charge: Conservation
+        of Charge</span>"}, {"shortId": "8vWesjNz@8", "id": "f2f59eb2-3373-4243-85f7-03c5e71a4258@8",
+        "title": "<span class=\"os-number\">18.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Conductors and Insulators</span>"}, {"shortId":
+        "4-YjJuu3@8", "id": "e3e62326-ebb7-4810-a202-e4e690745b76@8", "title": "<span
+        class=\"os-number\">18.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Coulomb&#8217;s
+        Law</span>"}, {"shortId": "25GAFXZF@10", "id": "db918015-7645-42cf-8bf7-64d09ad7b838@10",
+        "title": "<span class=\"os-number\">18.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Field: Concept of a Field Revisited</span>"},
+        {"shortId": "b00bMBx-@12", "id": "6f4d1b30-1c7e-440d-bcb4-26f1ffebe4d3@12",
+        "title": "<span class=\"os-number\">18.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Field Lines: Multiple Charges</span>"},
+        {"shortId": "JyYqGscQ@4", "id": "27262a1a-c710-4f5e-8d84-d2d962a23f8b@4",
+        "title": "<span class=\"os-number\">18.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Forces in Biology</span>"}, {"shortId":
+        "a8tWDdDr@7", "id": "6bcb560d-d0eb-4c91-9ac0-5ef46b68fd05@7", "title": "<span
+        class=\"os-number\">18.7</span><span class=\"os-divider\"> </span><span class=\"os-text\">Conductors
+        and Electric Fields in Static Equilibrium</span>"}, {"shortId": "Vq5TVUAL@8",
+        "id": "56ae5355-400b-4330-8552-980b0744e2ca@8", "title": "<span class=\"os-number\">18.8</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Applications of Electrostatics</span>"},
+        {"shortId": "Cg2R5f9-@14.79", "id": "0a0d91e5-ff7e-50fb-b1da-6600a28aef6a@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "gVVN5sQ5@14.79",
+        "id": "81554de6-c439-56a4-bd38-4c1190534cdc@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "2StquCmC@14.79", "id": "d92b6ab8-2982-5db7-b2ce-69d31337f9a0@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "X5yFZujt@14.79", "id": "5f9c8566-e8ed-56ad-96b0-3007924ca763@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">18</span><span class=\"os-divider\"> </span><span class=\"os-text\">Electric
+        Charge and Electric Field</span>"}, {"shortId": "f0smhGto@14.4", "id": "7f4b2684-6b68-52fa-a339-86e830a83e39@14.4",
+        "contents": [{"shortId": "VSd7m2xj@7", "id": "55277b9b-6c63-4439-8fef-464beaaa82b6@7",
+        "title": "<span class=\"os-text\">Introduction to Electric Potential and Electric
+        Energy</span>"}, {"shortId": "ZQxLs9GQ@6", "id": "650c4bb3-d190-44fd-9f2f-445a783abdec@6",
+        "title": "<span class=\"os-number\">19.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Potential Energy: Potential Difference</span>"},
+        {"shortId": "x5PMK8Cr@5", "id": "c793cc2b-c0ab-4089-a452-677700c3f9ac@5",
+        "title": "<span class=\"os-number\">19.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Potential in a Uniform Electric Field</span>"},
+        {"shortId": "KFPTOzE9@7", "id": "2853d33b-313d-47bf-8658-12eecf8cf548@7",
+        "title": "<span class=\"os-number\">19.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electrical Potential Due to a Point Charge</span>"},
+        {"shortId": "A4s9xQ1_@7", "id": "038b3dc5-0d7f-451b-aac0-94d4bd413b45@7",
+        "title": "<span class=\"os-number\">19.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Equipotential Lines</span>"}, {"shortId": "VtjKSKsR@7",
+        "id": "56d8ca48-ab11-477d-b800-31b812b036b2@7", "title": "<span class=\"os-number\">19.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Capacitors and Dielectrics</span>"},
+        {"shortId": "8JBnXbC0@6", "id": "f090675d-b0b4-4194-a4f0-084980010b4a@6",
+        "title": "<span class=\"os-number\">19.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Capacitors in Series and Parallel</span>"},
+        {"shortId": "dCm5PRBu@5", "id": "7429b93d-106e-417e-b01f-a68c04312d93@5",
+        "title": "<span class=\"os-number\">19.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Energy Stored in Capacitors</span>"}, {"shortId":
+        "j9L3NfPk@14.79", "id": "8fd2f735-f3e4-56d4-bc8a-c83034b00c18@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "fWwwRyM5@14.79",
+        "id": "7d6c3047-2339-5f60-93ea-c0a3c79f2839@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "Uspwb_ZX@14.79", "id": "52ca706f-f657-5704-b7a9-cccf72c56197@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "I1dtkhNz@14.79", "id": "23576d92-1373-54de-ae9c-104ab1be4d2e@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">19</span><span class=\"os-divider\"> </span><span class=\"os-text\">Electric
+        Potential and Electric Field</span>"}, {"shortId": "F5JvNVZh@14.3", "id":
+        "17926f35-5661-5421-be75-9a7c02a43e40@14.3", "contents": [{"shortId": "En9j99Z_@5",
+        "id": "127f63f7-d67f-4710-8625-2b1d4128ef6b@5", "title": "<span class=\"os-text\">Introduction
+        to Electric Current, Resistance, and Ohm''s Law</span>"}, {"shortId": "3ct4v3c5@7",
+        "id": "ddcb78bf-7739-4aea-abd2-ab6c07a16bf4@7", "title": "<span class=\"os-number\">20.1</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Current</span>"}, {"shortId":
+        "yLmi-MuP@8", "id": "c8b9a2f8-cb8f-484f-b53c-72459218c189@8", "title": "<span
+        class=\"os-number\">20.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Ohm&#8217;s
+        Law: Resistance and Simple Circuits</span>"}, {"shortId": "peIFjTvw@12", "id":
+        "a5e2058d-3bf0-4538-9e0d-d72e24a9acfd@12", "title": "<span class=\"os-number\">20.3</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Resistance and Resistivity</span>"},
+        {"shortId": "RJsc91ku@8", "id": "449b1cf7-592e-4625-8269-280bfa10d7ec@8",
+        "title": "<span class=\"os-number\">20.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Power and Energy</span>"}, {"shortId":
+        "IC3ZmZFw@9", "id": "202dd999-9170-4370-9c0c-61055833077d@9", "title": "<span
+        class=\"os-number\">20.5</span><span class=\"os-divider\"> </span><span class=\"os-text\">Alternating
+        Current versus Direct Current</span>"}, {"shortId": "P6z4gTAq@6", "id": "3facf881-302a-49af-bab8-60c569ecf7e5@6",
+        "title": "<span class=\"os-number\">20.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Hazards and the Human Body</span>"},
+        {"shortId": "QfVqqZCo@7", "id": "41f56aa9-90a8-4c05-95d7-2608497844bf@7",
+        "title": "<span class=\"os-number\">20.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Nerve Conduction&#8211;Electrocardiograms</span>"},
+        {"shortId": "mTTCuzd6@14.79", "id": "9934c2bb-377a-5706-b877-b771afe576c3@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "ZMsumMPn@14.79",
+        "id": "64cb2e98-c3e7-5bf4-82ac-3d2d53864e0f@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "khRE5lRk@14.79", "id": "921444e6-5464-51e9-a8b6-bbf3494ee724@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "OusU2hy_@14.79", "id": "3aeb14da-1cbf-59ba-82f6-263fdb13fa92@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">20</span><span class=\"os-divider\"> </span><span class=\"os-text\">Electric
+        Current, Resistance, and Ohm''s Law</span>"}, {"shortId": "a97Ct8rD@14.2",
+        "id": "6bdec2b7-cac3-5e00-a486-5cc3f56226d0@14.2", "contents": [{"shortId":
+        "E74qWTpP@7", "id": "13be2a59-3a4f-412d-90f0-78c9642ba82f@7", "title": "<span
+        class=\"os-text\">Introduction to Circuits and DC Instruments</span>"}, {"shortId":
+        "FLqArfdc@7", "id": "14ba80ad-f75c-4bdf-900e-b8c8ef4e4057@7", "title": "<span
+        class=\"os-number\">21.1</span><span class=\"os-divider\"> </span><span class=\"os-text\">Resistors
+        in Series and Parallel</span>"}, {"shortId": "cPzgoAtX@5", "id": "70fce0a0-0b57-44f4-9e0f-41e9cb5d862c@5",
+        "title": "<span class=\"os-number\">21.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electromotive Force: Terminal Voltage</span>"},
+        {"shortId": "tO43hIM5@7", "id": "b4ee3784-8339-4649-8341-5a9b2f3d1624@7",
+        "title": "<span class=\"os-number\">21.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Kirchhoff&#8217;s Rules</span>"}, {"shortId":
+        "Q7NR5SMN@9", "id": "43b351e5-230d-4ad8-b8df-1b3b02cf82cc@9", "title": "<span
+        class=\"os-number\">21.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">DC
+        Voltmeters and Ammeters</span>"}, {"shortId": "OLSvydAY@4", "id": "38b4afc9-d018-45b5-8873-1e9e0b1cd617@4",
+        "title": "<span class=\"os-number\">21.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Null Measurements</span>"}, {"shortId": "v9DiER6B@9",
+        "id": "bfd0e211-1e81-491b-a2e4-98942d2966f8@9", "title": "<span class=\"os-number\">21.6</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">DC Circuits Containing
+        Resistors and Capacitors</span>"}, {"shortId": "y-sVFxqZ@14.79", "id": "cbeb1517-1a99-5846-b9a0-c7233e7165a5@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "tEc9_3DW@14.79",
+        "id": "b4473dff-70d6-5823-9f18-10ad52633c41@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "wuCqno5l@14.79", "id": "c2e0aa9e-8e65-5cd6-a584-3cd93514b193@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "fVomuSTi@14.79", "id": "7d5a26b9-24e2-5aea-bc94-14214b5cbaab@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">21</span><span class=\"os-divider\"> </span><span class=\"os-text\">Circuits
+        and DC Instruments</span>"}, {"shortId": "7E3fyGoU@14.5", "id": "ec4ddfc8-6a14-5990-9a48-df2b0b67b21d@14.5",
+        "contents": [{"shortId": "UIsk7BfH@4", "id": "508b24ec-17c7-417d-9899-57dcab9d9dd4@4",
+        "title": "<span class=\"os-text\">Introduction to Magnetism</span>"}, {"shortId":
+        "fp2wm1sm@5", "id": "7e9db09b-5b26-42c7-b575-e54edb48ad24@5", "title": "<span
+        class=\"os-number\">22.1</span><span class=\"os-divider\"> </span><span class=\"os-text\">Magnets</span>"},
+        {"shortId": "UcUWmn05@8", "id": "51c5169a-7d39-4279-9baa-625410c2546f@8",
+        "title": "<span class=\"os-number\">22.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Ferromagnets and Electromagnets</span>"}, {"shortId":
+        "OGRpJCyi@4", "id": "38646924-2ca2-4da3-bfb7-1085797f79db@4", "title": "<span
+        class=\"os-number\">22.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Magnetic
+        Fields and Magnetic Field Lines</span>"}, {"shortId": "WdUpiW2x@8", "id":
+        "59d52989-6db1-42f9-83f9-6d9b29c901e7@8", "title": "<span class=\"os-number\">22.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Magnetic Field Strength:
+        Force on a Moving Charge in a Magnetic Field</span>"}, {"shortId": "pmp6Kk2R@5",
+        "id": "a66a7a2a-4d91-4887-8c5f-3757971a23b5@5", "title": "<span class=\"os-number\">22.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Force on a Moving Charge
+        in a Magnetic Field: Examples and Applications</span>"}, {"shortId": "8Ej0AEOI@5",
+        "id": "f048f400-4388-4969-b72b-c861f572e72f@5", "title": "<span class=\"os-number\">22.6</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">The Hall Effect</span>"},
+        {"shortId": "3HkJlnNh@7", "id": "dc790996-7361-4ce2-be86-fc5b26b1a101@7",
+        "title": "<span class=\"os-number\">22.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Magnetic Force on a Current-Carrying Conductor</span>"},
+        {"shortId": "s3dk0TST@4", "id": "b37764d1-3493-40de-a222-13f8b9e78b67@4",
+        "title": "<span class=\"os-number\">22.8</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Torque on a Current Loop: Motors and Meters</span>"},
+        {"shortId": "zQjQ0ydX@7", "id": "cd08d0d3-2757-47cb-b34b-d92f87e5992c@7",
+        "title": "<span class=\"os-number\">22.9</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Magnetic Fields Produced by Currents: Ampere&#8217;s
+        Law</span>"}, {"shortId": "r5wlv0QS@6", "id": "af9c25bf-4412-44c4-aadd-39450a5aa757@6",
+        "title": "<span class=\"os-number\">22.10</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Magnetic Force between Two Parallel Conductors</span>"},
+        {"shortId": "xBRU2UIQ@8", "id": "c41454d9-4210-45be-8ead-afaf3f5d80a8@8",
+        "title": "<span class=\"os-number\">22.11</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">More Applications of Magnetism</span>"}, {"shortId":
+        "Y6k-t5NT@14.79", "id": "63a93eb7-9353-5a4f-b013-8e2a4b58ee32@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "UN0KNYwc@14.79",
+        "id": "50dd0a35-8c1c-5f94-a565-3ff88c1ab35a@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "XVRXj2-9@14.79", "id": "5d54578f-6fbd-5227-9f54-1d68995f1938@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "wxTJVNvi@14.79", "id": "c314c954-dbe2-5e76-960b-fab86700a4ed@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">22</span><span class=\"os-divider\"> </span><span class=\"os-text\">Magnetism</span>"},
+        {"shortId": "RzEDhtWv@14.4", "id": "47310386-d5af-542a-844e-d54bc7d2f47f@14.4",
+        "contents": [{"shortId": "CUFax4cV@7", "id": "09415ac7-8715-4fb9-8983-27690fd615de@7",
+        "title": "<span class=\"os-text\">Introduction to Electromagnetic Induction,
+        AC Circuits and Electrical Technologies</span>"}, {"shortId": "seXQQ5S0@7",
+        "id": "b1e5d043-94b4-4741-a738-e5bf547b76de@7", "title": "<span class=\"os-number\">23.1</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Induced Emf and Magnetic
+        Flux</span>"}, {"shortId": "wGcsRRIg@10", "id": "c0672c45-1220-426e-b160-c859b879567d@10",
+        "title": "<span class=\"os-number\">23.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Faraday&#8217;s Law of Induction: Lenz&#8217;s
+        Law</span>"}, {"shortId": "vIQ7gdFd@6", "id": "bc843b81-d15d-4aa2-91ca-8ce8ea28df93@6",
+        "title": "<span class=\"os-number\">23.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Motional Emf</span>"}, {"shortId": "_4jMMU3o@4",
+        "id": "ff88cc31-4de8-4613-8001-0a421db11b04@4", "title": "<span class=\"os-number\">23.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Eddy Currents and Magnetic
+        Damping</span>"}, {"shortId": "tg55hGdA@7", "id": "b60e7984-6740-4a1e-b202-f1ba0f263486@7",
+        "title": "<span class=\"os-number\">23.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electric Generators</span>"}, {"shortId": "6emIq2lA@7",
+        "id": "e9e988ab-6940-444d-8879-b3cb9d3820eb@7", "title": "<span class=\"os-number\">23.6</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Back Emf</span>"}, {"shortId":
+        "_n3Pm8U3@9", "id": "fe7dcf9b-c537-4574-b596-6ce8d33f240b@9", "title": "<span
+        class=\"os-number\">23.7</span><span class=\"os-divider\"> </span><span class=\"os-text\">Transformers</span>"},
+        {"shortId": "jyBYMya4@4", "id": "8f205833-26b8-4eb4-98bb-936aad728cc6@4",
+        "title": "<span class=\"os-number\">23.8</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Electrical Safety: Systems and Devices</span>"},
+        {"shortId": "FSDecDOT@6", "id": "1520de70-3393-4fca-986e-e82658a6334b@6",
+        "title": "<span class=\"os-number\">23.9</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Inductance</span>"}, {"shortId": "eGuvoFK_@7",
+        "id": "786bafa0-52bf-499c-ad3f-5d44ef584e22@7", "title": "<span class=\"os-number\">23.10</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">RL Circuits</span>"},
+        {"shortId": "Zjt9wd9v@6", "id": "663b7dc1-df6f-4a85-bae8-10d20a358d01@6",
+        "title": "<span class=\"os-number\">23.11</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Reactance, Inductive and Capacitive</span>"},
+        {"shortId": "a_HE3fZB@9", "id": "6bf1c4dd-f641-41b2-ac66-29e159880c03@9",
+        "title": "<span class=\"os-number\">23.12</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">RLC Series AC Circuits</span>"}, {"shortId":
+        "fw4CnbT6@14.79", "id": "7f0e029d-b4fa-5ad0-83c1-0ad12af3e6b9@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "RvXmpGza@14.79",
+        "id": "46f5e6a4-6cda-5ed1-948c-c4391b51a5ef@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "CIDl3gg1@14.79", "id": "0880e5de-0835-5201-b73f-a0e68053b881@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "5LmUX9c6@14.79", "id": "e4b9945f-d73a-5edb-bf19-67eba53fd688@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">23</span><span class=\"os-divider\"> </span><span class=\"os-text\">Electromagnetic
+        Induction, AC Circuits, and Electrical Technologies</span>"}, {"shortId":
+        "npds-FAg@14.4", "id": "9e976cf8-5020-5b87-b493-e3264ab425ca@14.4", "contents":
+        [{"shortId": "2dO6Gqcp@5", "id": "d9d3ba1a-a729-44ce-8b7e-4a50ce471502@5",
+        "title": "<span class=\"os-text\">Introduction to Electromagnetic Waves</span>"},
+        {"shortId": "DPjTb9hQ@5", "id": "0cf8d36f-d850-4354-af24-bd2b7c7281dc@5",
+        "title": "<span class=\"os-number\">24.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Maxwell&#8217;s Equations: Electromagnetic
+        Waves Predicted and Observed</span>"}, {"shortId": "R_XAX-aM@9", "id": "47f5c05f-e68c-4218-9f5b-89e0b11d1e2d@9",
+        "title": "<span class=\"os-number\">24.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Production of Electromagnetic Waves</span>"},
+        {"shortId": "99yPqC9z@9", "id": "f7dc8fa8-2f73-4018-9bbc-3c1c496d71bf@9",
+        "title": "<span class=\"os-number\">24.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Electromagnetic Spectrum</span>"}, {"shortId":
+        "H0I4QwoD@6", "id": "1f423843-0a03-4075-ba33-23fe18eaaaf4@6", "title": "<span
+        class=\"os-number\">24.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Energy
+        in Electromagnetic Waves</span>"}, {"shortId": "qVbL6jCs@14.79", "id": "a956cbea-30ac-5cc8-9723-85e2e1d619de@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "7o9rHrUq@14.79",
+        "id": "ee8f6b1e-b52a-5b4d-a305-99f797e4503e@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "yoM-3Q_t@14.79", "id": "ca833edd-0fed-57a3-a92a-5b58c03a001b@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "GKPpTNm6@14.79", "id": "18a3e94c-d9ba-5c46-8735-fd96d5e8e712@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">24</span><span class=\"os-divider\"> </span><span class=\"os-text\">Electromagnetic
+        Waves</span>"}, {"shortId": "jVzns_oF@14.2", "id": "8d5ce7b3-fa05-5784-b50f-87ce869f04f4@14.2",
+        "contents": [{"shortId": "itIvTSi4@4", "id": "8ad22f4d-28b8-4d6b-9aa7-720e13c4fed0@4",
+        "title": "<span class=\"os-text\">Introduction to Geometric Optics</span>"},
+        {"shortId": "nOWj2nQA@6", "id": "9ce5a3da-7400-44fe-86f2-1f75041dd48e@6",
+        "title": "<span class=\"os-number\">25.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Ray Aspect of Light</span>"}, {"shortId":
+        "YLRye4Ke@6", "id": "60b4727b-829e-4ea7-9238-9140b6a1b20c@6", "title": "<span
+        class=\"os-number\">25.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">The
+        Law of Reflection</span>"}, {"shortId": "GO7yY4UT@12", "id": "18eef263-8513-4954-bcc8-07aa263f0a50@12",
+        "title": "<span class=\"os-number\">25.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Law of Refraction</span>"}, {"shortId":
+        "ALGlIz1W@11", "id": "00b1a523-3d56-49c4-bee1-dbb68cd25660@11", "title": "<span
+        class=\"os-number\">25.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Total
+        Internal Reflection</span>"}, {"shortId": "wiHR_GNo@9", "id": "c221d1fc-6368-440d-9d75-00f45fc0570d@9",
+        "title": "<span class=\"os-number\">25.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Dispersion: The Rainbow and Prisms</span>"},
+        {"shortId": "2Xfd9mm_@8", "id": "d977ddf6-69bf-46fd-8be6-5c41df45b092@8",
+        "title": "<span class=\"os-number\">25.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Image Formation by Lenses</span>"}, {"shortId":
+        "clTkbiG5@6", "id": "7254e46e-21b9-4466-81fe-a80923efa461@6", "title": "<span
+        class=\"os-number\">25.7</span><span class=\"os-divider\"> </span><span class=\"os-text\">Image
+        Formation by Mirrors</span>"}, {"shortId": "5ioKnkOa@14.79", "id": "e62a0a9e-439a-5c2b-9209-2fe994825f8d@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "KwoFDPHe@14.79",
+        "id": "2b0a050c-f1de-5864-9c34-9ee1a5946538@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "W0A9y5u1@14.79", "id": "5b403dcb-9bb5-523b-a10a-666b13c64fab@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "N6w6vKo-@14.79", "id": "37ac3abc-aa3e-5ca9-a390-eefbcdf20b69@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">25</span><span class=\"os-divider\"> </span><span class=\"os-text\">Geometric
+        Optics</span>"}, {"shortId": "AxCvU0Bq@14.1", "id": "0310af53-406a-583f-bdf4-69166baea275@14.1",
+        "contents": [{"shortId": "JmLkrYao@4", "id": "2662e4ad-86a8-41ad-a12b-bd4768f38548@4",
+        "title": "<span class=\"os-text\">Introduction to Vision and Optical Instruments</span>"},
+        {"shortId": "edFYqrQm@5", "id": "79d158aa-b426-4f73-b83a-f7d155c83478@5",
+        "title": "<span class=\"os-number\">26.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Physics of the Eye</span>"}, {"shortId": "KTP7ZmBy@4",
+        "id": "2933fb66-6072-4b03-9cb6-7f2cad674638@4", "title": "<span class=\"os-number\">26.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Vision Correction</span>"},
+        {"shortId": "1CyAfan6@8", "id": "d42c807d-a9fa-4e3d-83d0-0f7c745b51a0@8",
+        "title": "<span class=\"os-number\">26.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Color and Color Vision</span>"}, {"shortId":
+        "ErEwzMqS@5", "id": "12b130cc-ca92-47de-8d58-ac28ba04b4fd@5", "title": "<span
+        class=\"os-number\">26.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Microscopes</span>"},
+        {"shortId": "cIPippPy@5", "id": "7083e2a6-93f2-4abd-8418-f363ebf0c224@5",
+        "title": "<span class=\"os-number\">26.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Telescopes</span>"}, {"shortId": "aZtlHBQA@4",
+        "id": "699b651c-1400-46f0-9852-2cb4bb571693@4", "title": "<span class=\"os-number\">26.6</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Aberrations</span>"},
+        {"shortId": "A0Nz54DP@14.79", "id": "034373e7-80cf-564e-9c19-9f054e27efcc@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "AGvlf08z@14.79",
+        "id": "006be57f-4f33-5cbb-833d-f7a9d3c28a9c@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "aDS9F9Oz@14.79", "id": "6834bd17-d3b3-59aa-a283-61e454c5b179@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "GgXIiVlb@14.79", "id": "1a05c889-595b-5c31-9c2d-6cee574bb481@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">26</span><span class=\"os-divider\"> </span><span class=\"os-text\">Vision
+        and Optical Instruments</span>"}, {"shortId": "M_6sA7KM@14.1", "id": "33feac03-b28c-5cfc-acbb-f48ea0a2f9b5@14.1",
+        "contents": [{"shortId": "F4SwR6oI@5", "id": "1784b047-aa08-44f1-8680-09c3e38b41e0@5",
+        "title": "<span class=\"os-text\">Introduction to Wave Optics</span>"}, {"shortId":
+        "1b3GUlao@4", "id": "d5bdc652-56a8-4d6d-9836-1b9474cff734@4", "title": "<span
+        class=\"os-number\">27.1</span><span class=\"os-divider\"> </span><span class=\"os-text\">The
+        Wave Aspect of Light: Interference</span>"}, {"shortId": "lcpirnNj@5", "id":
+        "95ca62ae-7363-4fab-9700-81d2e2e82fda@5", "title": "<span class=\"os-number\">27.2</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Huygens''s Principle:
+        Diffraction</span>"}, {"shortId": "xT9BP3W2@6", "id": "c53f413f-75b6-44bd-b723-599d49a505fc@6",
+        "title": "<span class=\"os-number\">27.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Young&#8217;s Double Slit Experiment</span>"},
+        {"shortId": "hrzwRsbb@5", "id": "86bcf046-c6db-4096-a9de-2e16ea076c84@5",
+        "title": "<span class=\"os-number\">27.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Multiple Slit Diffraction</span>"}, {"shortId":
+        "qsjr0i21@5", "id": "aac8ebd2-2db5-4b82-a4b2-4f2005643abe@5", "title": "<span
+        class=\"os-number\">27.5</span><span class=\"os-divider\"> </span><span class=\"os-text\">Single
+        Slit Diffraction</span>"}, {"shortId": "9ANhisjh@7", "id": "f403618a-c8e1-4b20-8737-6164df697aea@7",
+        "title": "<span class=\"os-number\">27.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Limits of Resolution: The Rayleigh Criterion</span>"},
+        {"shortId": "bNXE8_FU@7", "id": "6cd5c4f3-f154-4617-912b-c12f47dd6429@7",
+        "title": "<span class=\"os-number\">27.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Thin Film Interference</span>"}, {"shortId":
+        "ARn-fU0a@6", "id": "0119fe7d-4d1a-42de-b580-aa46659f8228@6", "title": "<span
+        class=\"os-number\">27.8</span><span class=\"os-divider\"> </span><span class=\"os-text\">Polarization</span>"},
+        {"shortId": "DMKzyEh-@4", "id": "0cc2b3c8-487e-49ea-925f-ff51cb2a0591@4",
+        "title": "<span class=\"os-number\">27.9</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">*Extended Topic* Microscopy Enhanced by the
+        Wave Characteristics of Light</span>"}, {"shortId": "PPSzFz2s@14.79", "id":
+        "3cf4b317-3dac-5494-9789-cc77227e257a@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "YAawl8Qj@14.79", "id": "6006b097-c423-5b23-8467-18faa61494ef@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "r3JoAyS5@14.79",
+        "id": "af726803-24b9-56d9-8c44-11045f603af3@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "pRPG95ri@14.79", "id": "a513c6f7-9ae2-51ae-b32f-03908c13de30@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">27</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Wave Optics</span>"}, {"shortId": "A3M5vlTo@14.1", "id":
+        "037339be-54e8-524b-8299-480beceac740@14.1", "contents": [{"shortId": "c3LUpAha@7",
+        "id": "7372d4a4-085a-4018-8588-9801e44b636f@7", "title": "<span class=\"os-text\">Introduction
+        to Special Relativity</span>"}, {"shortId": "Jhetn25W@5", "id": "2617ad9f-6e56-4ebc-aba7-2236e3b07e46@5",
+        "title": "<span class=\"os-number\">28.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Einstein&#8217;s Postulates</span>"}, {"shortId":
+        "1lVagIDY@11", "id": "d6555a80-80d8-4829-9346-07ea9391f391@11", "title": "<span
+        class=\"os-number\">28.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Simultaneity
+        And Time Dilation</span>"}, {"shortId": "8s9HWA_d@5", "id": "f2cf4758-0fdd-4c2c-ad7a-8814148ac022@5",
+        "title": "<span class=\"os-number\">28.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Length Contraction</span>"}, {"shortId": "46QSIK8_@10",
+        "id": "e3a41220-af3f-40c6-b8ba-1a5d1bcbed92@10", "title": "<span class=\"os-number\">28.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Relativistic Addition
+        of Velocities</span>"}, {"shortId": "y0dBCP5n@6", "id": "cb474108-fe67-4904-bdbe-441b271ec10f@6",
+        "title": "<span class=\"os-number\">28.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Relativistic Momentum</span>"}, {"shortId":
+        "lbRvdjGZ@11", "id": "95b46f76-3199-4411-94ca-5318fff41746@11", "title": "<span
+        class=\"os-number\">28.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">Relativistic
+        Energy</span>"}, {"shortId": "FiHws5AN@14.79", "id": "1621f0b3-900d-5460-ae2c-87f378dd0474@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "dExuJn9q@14.79",
+        "id": "744c6e26-7f6a-5648-b27b-96be31124d80@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "2Smb2_V8@14.79", "id": "d9299bdb-f57c-5eb2-8996-7ed81388c703@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "_FWpHF_A@14.79", "id": "fc55a91c-5fc0-5b72-94cb-e2ae46685acd@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">28</span><span class=\"os-divider\"> </span><span class=\"os-text\">Special
+        Relativity</span>"}, {"shortId": "2Z-Mvdch@14.6", "id": "d99f8cbd-d721-52f8-b18a-40f20dc31989@14.6",
+        "contents": [{"shortId": "vXY8BYJg@4", "id": "bd763c05-8260-4a8d-9aa1-5d96f49556e4@4",
+        "title": "<span class=\"os-text\">Introduction to Quantum Physics</span>"},
+        {"shortId": "xuwQZnCi@10", "id": "c6ec1066-70a2-4971-b7ef-cd091877b264@10",
+        "title": "<span class=\"os-number\">29.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Quantization of Energy</span>"}, {"shortId":
+        "x962MmIi@9", "id": "c7deb632-6222-4c11-8ee8-45758b396ed3@9", "title": "<span
+        class=\"os-number\">29.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">The
+        Photoelectric Effect</span>"}, {"shortId": "TfOT0NVQ@11", "id": "4df393d0-d550-4c64-bd52-bce4f056d547@11",
+        "title": "<span class=\"os-number\">29.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Photon Energies and the Electromagnetic Spectrum</span>"},
+        {"shortId": "ipIHqMAG@6", "id": "8a9207a8-c006-4ef7-b399-2960a5dcc23b@6",
+        "title": "<span class=\"os-number\">29.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Photon Momentum</span>"}, {"shortId": "AUfBFVLn@6",
+        "id": "0147c115-52e7-43ac-8117-2f285e76152b@6", "title": "<span class=\"os-number\">29.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">The Particle-Wave Duality</span>"},
+        {"shortId": "lpOKRuT0@7", "id": "96938a46-e4f4-473e-825a-61e8ccb53e09@7",
+        "title": "<span class=\"os-number\">29.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Wave Nature of Matter</span>"}, {"shortId":
+        "1FsgT0s6@8", "id": "d45b204f-4b3a-4c7a-9018-d091e9270579@8", "title": "<span
+        class=\"os-number\">29.7</span><span class=\"os-divider\"> </span><span class=\"os-text\">Probability:
+        The Heisenberg Uncertainty Principle</span>"}, {"shortId": "O4TWqxKR@8", "id":
+        "3b84d6ab-1291-4e6a-8510-7772c0de699e@8", "title": "<span class=\"os-number\">29.8</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">The Particle-Wave Duality
+        Reviewed</span>"}, {"shortId": "ziNVhLiP@14.79", "id": "ce235584-b88f-52f6-9461-a151546b440a@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "cqLMhBP2@14.79",
+        "id": "72a2cc84-13f6-5616-aced-057e946133a6@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "PS7noFzq@14.79", "id": "3d2ee7a0-5cea-5383-96c4-b3e4924c1dda@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "mGceyGzd@14.79", "id": "98671ec8-6cdd-5f1b-a205-2352cdc385f0@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">29</span><span class=\"os-divider\"> </span><span class=\"os-text\">Introduction
+        to Quantum Physics</span>"}, {"shortId": "DR0ZST3Q@14.2", "id": "0d1d1949-3dd0-5eb1-aa68-a46398958d51@14.2",
+        "contents": [{"shortId": "BSCCZiN0@4", "id": "05208266-2374-4008-9060-7ddddbe877f2@4",
+        "title": "<span class=\"os-text\">Introduction to Atomic Physics</span>"},
+        {"shortId": "wKYIsSV1@4", "id": "c0a608b1-2575-457f-8284-f5dea528053d@4",
+        "title": "<span class=\"os-number\">30.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Discovery of the Atom</span>"}, {"shortId":
+        "fsw4uvhV@10", "id": "7ecc38ba-f855-43c4-bad7-50c40b70556d@10", "title": "<span
+        class=\"os-number\">30.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Discovery
+        of the Parts of the Atom: Electrons and Nuclei</span>"}, {"shortId": "mirSSr3Q@11",
+        "id": "9a2ad24a-bdd0-4aa8-a99c-36ba54ec0f1f@11", "title": "<span class=\"os-number\">30.3</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Bohr&#8217;s Theory of
+        the Hydrogen Atom</span>"}, {"shortId": "9-AWozSC@6", "id": "f7e016a3-3482-45f8-8b0e-857808864cfe@6",
+        "title": "<span class=\"os-number\">30.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">X Rays: Atomic Origins and Applications</span>"},
+        {"shortId": "z6GcSqgz@4", "id": "cfa19c4a-a833-400b-aaa8-a74479d13886@4",
+        "title": "<span class=\"os-number\">30.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Applications of Atomic Excitations and De-Excitations</span>"},
+        {"shortId": "rt2I8D90@6", "id": "aedd88f0-3f74-4137-b2f1-67af8b4d7832@6",
+        "title": "<span class=\"os-number\">30.6</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Wave Nature of Matter Causes Quantization</span>"},
+        {"shortId": "_qlSPJPN@4", "id": "fea9523c-93cd-487c-bb4c-b2b367f5c279@4",
+        "title": "<span class=\"os-number\">30.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Patterns in Spectra Reveal More Quantization</span>"},
+        {"shortId": "wfBXbxNm@14", "id": "c1f0576f-1366-45d2-8f18-a54b8b35c1c5@14",
+        "title": "<span class=\"os-number\">30.8</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Quantum Numbers and Rules</span>"}, {"shortId":
+        "UGpL_FUi@11", "id": "506a4bfc-5522-4aa6-9b9c-0e7e2325dda0@11", "title": "<span
+        class=\"os-number\">30.9</span><span class=\"os-divider\"> </span><span class=\"os-text\">The
+        Pauli Exclusion Principle</span>"}, {"shortId": "b4XIXcbE@14.79", "id": "6f85c85d-c6c4-510b-8cd3-adbb6c18e495@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "wbSrLcbc@14.79",
+        "id": "c1b4ab2d-c6dc-559f-a0fb-95e342465757@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "C--UGIN4@14.79", "id": "0bef9418-8378-5d49-a4bf-1ba461b26208@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "BFc4Lbzl@14.79", "id": "0457382d-bce5-5d03-a959-99134f0ea72b@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">30</span><span class=\"os-divider\"> </span><span class=\"os-text\">Atomic
+        Physics</span>"}, {"shortId": "VZpcBO5b@14.7", "id": "559a5c04-ee5b-526f-9791-70ae150a3dab@14.7",
+        "contents": [{"shortId": "pg7t-syq@5", "id": "a60eedfa-ccaa-4fef-b09f-36e7ad3eaa17@5",
+        "title": "<span class=\"os-text\">Introduction to Radioactivity and Nuclear
+        Physics</span>"}, {"shortId": "fjWtUHJu@12", "id": "7e35ad50-726e-4379-9152-c03fa312f746@12",
+        "title": "<span class=\"os-number\">31.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Nuclear Radioactivity</span>"}, {"shortId":
+        "Aw83H98P@8", "id": "030f371f-df0f-44f0-b7bf-1a8c8733ae0c@8", "title": "<span
+        class=\"os-number\">31.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Radiation
+        Detection and Detectors</span>"}, {"shortId": "AKg0yriU@5", "id": "00a834ca-b894-44cd-893c-efcb52b58f72@5",
+        "title": "<span class=\"os-number\">31.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Substructure of the Nucleus</span>"}, {"shortId":
+        "mGo3BXtW@9", "id": "986a3705-7b56-4f11-9d04-25d028307f7a@9", "title": "<span
+        class=\"os-number\">31.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Nuclear
+        Decay and Conservation Laws</span>"}, {"shortId": "B00gSDuK@9", "id": "074d2048-3b8a-4014-bf01-e0c56e219447@9",
+        "title": "<span class=\"os-number\">31.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Half-Life and Activity</span>"}, {"shortId":
+        "4Stg9XLf@9", "id": "e12b60f5-72df-401e-a1b1-7f13fd61eee0@9", "title": "<span
+        class=\"os-number\">31.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">Binding
+        Energy</span>"}, {"shortId": "8vd55Umb@8", "id": "f2f779e5-499b-4104-b62c-0ba44b60f13e@8",
+        "title": "<span class=\"os-number\">31.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Tunneling</span>"}, {"shortId": "Ut8a0IE7@14.79",
+        "id": "52df1ad0-813b-51cd-b53f-f717c7078e2b@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "UyOJrEKR@14.79", "id": "532389ac-4291-5bca-a0b5-44052f137269@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "41MGSZ-b@14.79",
+        "id": "e3530649-9f9b-508d-a7dc-4ff203d14181@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "4xcHJ0Sv@14.79", "id": "e3170727-44af-53af-97df-8a884bf908ae@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">31</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Radioactivity and Nuclear Physics</span>"}, {"shortId":
+        "5RNSp_H3@14.6", "id": "e51352a7-f1f7-5431-8d89-c6d56f644ec4@14.6", "contents":
+        [{"shortId": "pGns41xf@6", "id": "a469ece3-5c5f-46bd-a983-8a99ef997d9b@6",
+        "title": "<span class=\"os-text\">Introduction to Applications of Nuclear
+        Physics</span>"}, {"shortId": "grLv8IGh@8", "id": "82b2eff0-81a1-4672-b7ef-6f8bcc7c679b@8",
+        "title": "<span class=\"os-number\">32.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Medical Imaging and Diagnostics</span>"}, {"shortId":
+        "HIE-QsS9@8", "id": "1c813e42-c4bd-406c-900e-82faf8875592@8", "title": "<span
+        class=\"os-number\">32.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Biological
+        Effects of Ionizing Radiation</span>"}, {"shortId": "lu1oSSK7@7", "id": "96ed6849-22bb-4178-a008-6c09bd197dc6@7",
+        "title": "<span class=\"os-number\">32.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Therapeutic Uses of Ionizing Radiation</span>"},
+        {"shortId": "zpnn1A0-@6", "id": "ce99e7d4-0d3e-41dc-b7db-558908cdace5@6",
+        "title": "<span class=\"os-number\">32.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Food Irradiation</span>"}, {"shortId": "YlQXf-yr@9",
+        "id": "6254177f-ecab-4cc5-8c45-d7de363ceef8@9", "title": "<span class=\"os-number\">32.5</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Fusion</span>"}, {"shortId":
+        "LJeKXQqg@13", "id": "2c978a5d-0aa0-4a0e-b27f-675c2f726e51@13", "title": "<span
+        class=\"os-number\">32.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">Fission</span>"},
+        {"shortId": "l6yVr4Gm@7", "id": "97ac95af-81a6-44e4-8905-44f6de003165@7",
+        "title": "<span class=\"os-number\">32.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Nuclear Weapons</span>"}, {"shortId": "y0rYd2BI@14.79",
+        "id": "cb4ad877-6048-5c5a-b794-03f2bf4ddd39@14.79", "title": "<span class=\"os-text\">Glossary</span>"},
+        {"shortId": "wFyqVRZc@14.79", "id": "c05caa55-165c-5f7b-bfe2-014396de77c3@14.79",
+        "title": "<span class=\"os-text\">Section Summary</span>"}, {"shortId": "HBsZm9P1@14.79",
+        "id": "1c1b199b-d3f5-5a5e-8cc5-1e97b759c771@14.79", "title": "<span class=\"os-text\">Conceptual
+        Questions</span>"}, {"shortId": "Qi750jt-@14.79", "id": "422ef9d2-3b7e-53a2-b50d-6e4ad89c1757@14.79",
+        "title": "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title":
+        "<span class=\"os-number\">32</span><span class=\"os-divider\"> </span><span
+        class=\"os-text\">Medical Applications of Nuclear Physics</span>"}, {"shortId":
+        "_8knh9_j@14.1", "id": "ffc92787-dfe3-51e9-a2b8-6c041056c690@14.1", "contents":
+        [{"shortId": "Q6hKu32v@7", "id": "43a84abb-7daf-467e-ae21-b1b74baab670@7",
+        "title": "<span class=\"os-text\">Introduction to Particle Physics</span>"},
+        {"shortId": "g42fK9Zb@5", "id": "838d9f2b-d65b-44a7-b2d1-7897af0bc74f@5",
+        "title": "<span class=\"os-number\">33.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Yukawa Particle and the Heisenberg Uncertainty
+        Principle Revisited</span>"}, {"shortId": "JQqhSmdZ@7", "id": "250aa14a-6759-48e1-8f7e-1b85911dd18e@7",
+        "title": "<span class=\"os-number\">33.2</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">The Four Basic Forces</span>"}, {"shortId":
+        "aypTUEkP@6", "id": "6b2a5350-490f-4468-93d4-e201a6ba4c4a@6", "title": "<span
+        class=\"os-number\">33.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Accelerators
+        Create Matter from Energy</span>"}, {"shortId": "uD-tbs70@7", "id": "b83fad6e-cef4-424c-a84f-7004bedc527b@7",
+        "title": "<span class=\"os-number\">33.4</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Particles, Patterns, and Conservation Laws</span>"},
+        {"shortId": "dlKSAfwB@8", "id": "76529201-fc01-415e-be4d-f735e826206c@8",
+        "title": "<span class=\"os-number\">33.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Quarks: Is That All There Is?</span>"}, {"shortId":
+        "MSlGKY6L@9", "id": "31294629-8e8b-4eb1-9780-3d48345b9d88@9", "title": "<span
+        class=\"os-number\">33.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">GUTs:
+        The Unification of Forces</span>"}, {"shortId": "Jn2YGsgr@14.79", "id": "267d981a-c82b-5c6e-9a35-db7438b43a29@14.79",
+        "title": "<span class=\"os-text\">Glossary</span>"}, {"shortId": "Bi5GbFRC@14.79",
+        "id": "062e466c-5442-56de-907e-0080de4e1b5e@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "6OaZUt9j@14.79", "id": "e8e69952-df63-582a-8be3-e8181998f8de@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "iYyBoCsz@14.79", "id": "898c81a0-2b33-5f1b-b678-042d9ed941c2@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">33</span><span class=\"os-divider\"> </span><span class=\"os-text\">Particle
+        Physics</span>"}, {"shortId": "LbHfFzl-@14.1", "id": "2db1df17-397e-5db7-8c65-53d87a28afd8@14.1",
+        "contents": [{"shortId": "MUE8JENr@6", "id": "31413c24-436b-4e72-861c-0dfca1f6f1e0@6",
+        "title": "<span class=\"os-text\">Introduction to Frontiers of Physics</span>"},
+        {"shortId": "Fw4kwPag@10", "id": "170e24c0-f6a0-428a-b8a3-ac313e996e19@10",
+        "title": "<span class=\"os-number\">34.1</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Cosmology and Particle Physics</span>"}, {"shortId":
+        "5AeKbonU@8", "id": "e4078a6e-89d4-472a-bb01-8e299d7ba0aa@8", "title": "<span
+        class=\"os-number\">34.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">General
+        Relativity and Quantum Gravity</span>"}, {"shortId": "hJCgedIf@5", "id": "8490a079-d21f-4e21-88f1-2a3f5211e372@5",
+        "title": "<span class=\"os-number\">34.3</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Superstrings</span>"}, {"shortId": "Vml4G3c9@7",
+        "id": "5669781b-773d-4868-bea5-5c3b06ea91af@7", "title": "<span class=\"os-number\">34.4</span><span
+        class=\"os-divider\"> </span><span class=\"os-text\">Dark Matter and Closure</span>"},
+        {"shortId": "4UR0Q_y2@4", "id": "e1447443-fcb6-4b55-b3fc-2bde086ff569@4",
+        "title": "<span class=\"os-number\">34.5</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Complexity and Chaos</span>"}, {"shortId":
+        "SDYO23Ns@7", "id": "48360edb-736c-4f9f-9a40-1beef1ddd2c1@7", "title": "<span
+        class=\"os-number\">34.6</span><span class=\"os-divider\"> </span><span class=\"os-text\">High-temperature
+        Superconductors</span>"}, {"shortId": "zoPMytrn@5", "id": "ce83ccca-dae7-461b-a20f-b853471543b8@5",
+        "title": "<span class=\"os-number\">34.7</span><span class=\"os-divider\">
+        </span><span class=\"os-text\">Some Questions We Know to Ask</span>"}, {"shortId":
+        "JEBWU7ws@14.79", "id": "24405653-bc2c-592d-9249-7a5fe2134d8f@14.79", "title":
+        "<span class=\"os-text\">Glossary</span>"}, {"shortId": "fpqtFGpS@14.79",
+        "id": "7e9aad14-6a52-55b6-85d5-512a122e9d8e@14.79", "title": "<span class=\"os-text\">Section
+        Summary</span>"}, {"shortId": "bPci3klE@14.79", "id": "6cf722de-4944-5fc3-8a8e-ee3b536cc330@14.79",
+        "title": "<span class=\"os-text\">Conceptual Questions</span>"}, {"shortId":
+        "DxD75Mom@14.79", "id": "0f10fbe4-ca26-5075-985b-839701cea200@14.79", "title":
+        "<span class=\"os-text\">Problems &amp; Exercises</span>"}], "title": "<span
+        class=\"os-number\">34</span><span class=\"os-divider\"> </span><span class=\"os-text\">Frontiers
+        of Physics</span>"}, {"shortId": "qvMKVKNW@8", "id": "aaf30a54-a356-4c5f-8c0d-2f55e4d20556@8",
+        "title": "<span class=\"os-number\">A</span><span class=\"os-divider\"> |
+        </span><span class=\"os-text\">Atomic Masses</span>"}, {"shortId": "Zm9TNedC@7",
+        "id": "666f5335-e742-451e-b7ff-245efeff8bd9@7", "title": "<span class=\"os-number\">B</span><span
+        class=\"os-divider\"> | </span><span class=\"os-text\">Selected Radioactive
+        Isotopes</span>"}, {"shortId": "cjQyhWg-@11", "id": "72343285-683e-46d9-a6c2-5de097e36ff9@11",
+        "title": "<span class=\"os-number\">C</span><span class=\"os-divider\"> |
+        </span><span class=\"os-text\">Useful Information</span>"}, {"shortId": "-dfg-33I@9",
+        "id": "f9d7e0fb-7dc8-471a-b4d8-976fce44baa0@9", "title": "<span class=\"os-number\">D</span><span
+        class=\"os-divider\"> | </span><span class=\"os-text\">Glossary of Key Symbols
+        and Notation</span>"}, {"shortId": "2QAOyLaX@14.79", "id": "d9000ec8-b697-5ab0-b8b6-8d2f587f1684@14.79",
+        "title": "<span class=\"os-text\">Index</span>"}], "title": "College Physics"},
+        "doctype": "", "buyLink": null, "submitter": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}, "collated": true, "baked": "2019-03-20T14:24:26.164476-05:00",
+        "parentAuthors": [], "history": [{"changes": "resolving typo from erratum
+        8200 - CP", "version": "14.79", "revised": "2019-03-20T19:23:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.78", "revised": "2019-03-06T14:28:57Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.77", "revised": "2019-03-06T14:25:22Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.76", "revised": "2019-03-06T14:21:45Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.75", "revised": "2019-03-06T14:18:55Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.74", "revised": "2019-03-05T22:22:29Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.73", "revised": "2019-03-05T22:21:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.72", "revised": "2019-03-05T22:20:37Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.71", "revised": "2019-03-05T22:19:12Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.70", "revised": "2019-03-05T22:14:14Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.69", "revised": "2019-03-05T22:13:21Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.68", "revised": "2019-03-05T22:11:14Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.67", "revised": "2019-03-05T22:08:51Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.66", "revised": "2019-03-05T22:05:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.65", "revised": "2019-03-05T21:55:26Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.64", "revised": "2019-03-05T21:50:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.63", "revised": "2019-03-05T21:49:07Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.62", "revised": "2019-03-05T21:45:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.61", "revised": "2019-03-05T21:43:17Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.60", "revised": "2019-03-05T21:39:47Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.59", "revised": "2019-03-05T21:37:48Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.58", "revised": "2019-03-05T21:36:53Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "github
+        635 -TM", "version": "14.57", "revised": "2019-03-05T21:28:08Z", "publisher":
+        {"surname": "Masciale", "suffix": null, "firstname": "Theresa", "title": "",
+        "fullname": "Theresa Masciale", "id": "tmasciale"}}, {"changes": "#635 -TM",
+        "version": "14.56", "revised": "2019-03-05T18:05:02Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "test", "version":
+        "14.55", "revised": "2019-03-05T17:52:00Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "test", "version": "14.54", "revised":
+        "2019-03-05T17:40:58Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "github #635 -TM", "version": "14.53", "revised":
+        "2019-03-05T17:27:02Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "github #635 -TM", "version": "14.52", "revised":
+        "2019-03-05T17:19:16Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "github #635 -TM", "version": "14.51", "revised":
+        "2019-03-05T17:00:21Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "github #635 -TM", "version": "14.50", "revised":
+        "2019-03-05T16:44:23Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "github issue #635 -TM", "version": "14.49",
+        "revised": "2019-03-05T16:35:29Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "overflowing a sim as a temp fix so that it
+        can be used until we figure out how to get it to scale properly - cp", "version":
+        "14.48", "revised": "2019-03-04T17:20:25Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "phet link", "version": "14.47",
+        "revised": "2019-03-04T16:37:36Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "Phets link fixed -TM", "version": "14.46",
+        "revised": "2019-03-04T16:23:03Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "github #635 -TM", "version": "14.45", "revised":
+        "2019-03-04T15:20:33Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "modified size of sim to fix overflow - cp",
+        "version": "14.44", "revised": "2019-02-27T15:11:53Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "bake", "version":
+        "14.43", "revised": "2019-01-22T18:17:31Z", "publisher": {"surname": "OpenStax
+        College", "suffix": "", "firstname": "", "title": "", "fullname": "OpenStax",
+        "id": "OpenStaxCollege"}}, {"changes": "errata 7452", "version": "14.42",
+        "revised": "2019-01-17T22:15:02Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7518", "version": "14.41", "revised":
+        "2019-01-17T22:08:48Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7518", "version": "14.40", "revised":
+        "2019-01-17T22:02:12Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7518", "version": "14.39", "revised":
+        "2019-01-17T22:00:35Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7399", "version": "14.38", "revised":
+        "2019-01-17T21:56:28Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7387", "version": "14.37", "revised":
+        "2019-01-17T21:30:37Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7387", "version": "14.36", "revised":
+        "2019-01-17T21:27:45Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7387", "version": "14.35", "revised":
+        "2019-01-17T21:22:35Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7387", "version": "14.34", "revised":
+        "2019-01-17T21:14:18Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7387", "version": "14.33", "revised":
+        "2019-01-17T21:05:54Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7387", "version": "14.32", "revised":
+        "2019-01-17T21:03:26Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7382", "version": "14.31", "revised":
+        "2019-01-17T20:52:26Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7192", "version": "14.30", "revised":
+        "2019-01-17T20:39:32Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7114", "version": "14.29", "revised":
+        "2019-01-17T20:30:56Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7104", "version": "14.28", "revised":
+        "2019-01-17T20:19:34Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7012", "version": "14.27", "revised":
+        "2019-01-17T20:06:12Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7011", "version": "14.26", "revised":
+        "2019-01-17T20:00:34Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6792", "version": "14.25", "revised":
+        "2019-01-17T19:56:27Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6648", "version": "14.24", "revised":
+        "2019-01-17T19:48:05Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7519", "version": "14.23", "revised":
+        "2019-01-17T19:41:08Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6546", "version": "14.22", "revised":
+        "2019-01-17T19:15:12Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6952", "version": "14.21", "revised":
+        "2019-01-17T18:58:27Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6540", "version": "14.20", "revised":
+        "2019-01-17T18:52:32Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6430", "version": "14.19", "revised":
+        "2019-01-17T18:46:39Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6416", "version": "14.18", "revised":
+        "2019-01-17T18:14:47Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6392", "version": "14.17", "revised":
+        "2019-01-17T18:04:23Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6392", "version": "14.16", "revised":
+        "2019-01-17T17:57:29Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6392", "version": "14.15", "revised":
+        "2019-01-17T17:53:18Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6392", "version": "14.14", "revised":
+        "2019-01-17T17:50:26Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6392", "version": "14.13", "revised":
+        "2019-01-17T17:43:53Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6392", "version": "14.12", "revised":
+        "2019-01-17T17:27:57Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6349", "version": "14.11", "revised":
+        "2019-01-17T17:14:23Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6342", "version": "14.10", "revised":
+        "2019-01-17T17:03:24Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6247", "version": "14.9", "revised":
+        "2019-01-17T16:38:28Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7076", "version": "14.8", "revised":
+        "2019-01-17T16:30:15Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6326", "version": "14.7", "revised":
+        "2019-01-17T16:25:58Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6773", "version": "14.6", "revised":
+        "2019-01-17T16:06:09Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 6643", "version": "14.5", "revised":
+        "2019-01-17T15:55:46Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7380\r\n", "version": "14.4", "revised":
+        "2018-11-08T19:47:10Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7365", "version": "14.3", "revised":
+        "2018-11-06T19:02:51Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "errata 7038", "version": "14.2", "revised":
+        "2018-10-02T16:18:06Z", "publisher": {"surname": "OpenStax College", "suffix":
+        "", "firstname": "", "title": "", "fullname": "OpenStax", "id": "OpenStaxCollege"}},
+        {"changes": "BAKE IT UP", "version": "14.1", "revised": "2018-09-26T15:23:08Z",
+        "publisher": {"surname": "OpenStax College", "suffix": "", "firstname": "",
+        "title": "", "fullname": "OpenStax", "id": "OpenStaxCollege"}}, {"changes":
+        "errata 5802", "version": "13.65", "revised": "2018-09-21T14:27:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.64", "revised": "2018-09-19T00:09:19Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.63", "revised": "2018-09-19T00:04:17Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.62", "revised": "2018-09-19T00:01:28Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.61", "revised": "2018-09-19T00:00:19Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.60", "revised": "2018-09-18T23:58:06Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.59", "revised": "2018-09-18T23:54:39Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.58", "revised": "2018-09-18T23:52:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.57", "revised": "2018-09-18T23:49:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.56", "revised": "2018-09-18T23:44:58Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.55", "revised": "2018-09-18T23:42:20Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.54", "revised": "2018-09-18T23:40:16Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.53", "revised": "2018-09-18T23:36:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.52", "revised": "2018-09-18T23:36:08Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.51", "revised": "2018-09-18T23:30:42Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.50", "revised": "2018-09-18T23:29:37Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.49", "revised": "2018-09-18T23:27:22Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.48", "revised": "2018-09-18T23:25:00Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.47", "revised": "2018-09-18T23:19:06Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.46", "revised": "2018-09-18T23:14:49Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.45", "revised": "2018-09-18T23:08:42Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.44", "revised": "2018-09-18T23:01:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.43", "revised": "2018-09-18T23:00:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.42", "revised": "2018-09-18T22:55:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.41", "revised": "2018-09-18T22:52:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.40", "revised": "2018-09-18T22:50:00Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.39", "revised": "2018-09-18T22:44:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.38", "revised": "2018-09-18T22:43:58Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.37", "revised": "2018-09-18T22:38:48Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.36", "revised": "2018-09-18T22:37:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.35", "revised": "2018-09-18T22:33:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.34", "revised": "2018-09-18T22:30:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.33", "revised": "2018-09-18T22:27:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.32", "revised": "2018-09-18T22:25:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag on phet", "version": "13.31", "revised": "2018-09-18T22:23:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.30", "revised": "2018-09-18T22:18:46Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.29", "revised": "2018-09-18T22:15:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.28", "revised": "2018-09-18T22:14:35Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.27", "revised": "2018-09-18T22:11:01Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.26", "revised": "2018-09-18T22:10:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.25", "revised": "2018-09-18T22:04:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.24", "revised": "2018-09-18T21:14:14Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.23", "revised": "2018-09-18T21:11:15Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.22", "revised": "2018-09-18T21:06:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.21", "revised": "2018-09-18T20:46:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "figure
+        tag to phet", "version": "13.20", "revised": "2018-09-18T20:33:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "put figure
+        tag back on phet", "version": "13.19", "revised": "2018-09-18T19:44:19Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "added figure tag back to phet", "version": "13.18", "revised": "2018-09-18T18:05:59Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "added figure tag back to phet", "version": "13.17", "revised": "2018-09-18T18:00:38Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "added figure tag back to phet", "version": "13.16", "revised": "2018-09-18T17:55:35Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "added figure tag back to phet", "version": "13.15", "revised": "2018-09-18T17:52:47Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "appendix link anchor text", "version": "13.14", "revised": "2018-09-18T15:12:32Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "figure tag on phet", "version": "13.13", "revised": "2018-09-18T14:55:11Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "removed equation numbers from exercises", "version": "13.12", "revised":
+        "2018-09-06T22:21:25Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "changed phet height", "version": "13.11", "revised":
+        "2018-09-06T21:58:30Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "added figure tag back to phet", "version":
+        "13.10", "revised": "2018-09-06T21:44:46Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "removed metadata summary LOs",
+        "version": "13.9", "revised": "2018-09-06T21:28:47Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "removed metadata
+        summary LOs", "version": "13.8", "revised": "2018-09-06T21:27:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "deleted
+        metadata summary LOs", "version": "13.7", "revised": "2018-09-06T21:21:54Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "added figure tag to phet", "version": "13.6", "revised": "2018-09-06T20:32:46Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "roles fix", "version": "13.5", "revised": "2018-09-04T16:06:52Z", "publisher":
+        {"surname": "Stickney", "suffix": "", "firstname": "Ryan", "title": "", "fullname":
+        "Ryan Stickney", "id": "sanura"}}, {"changes": "aligned table left", "version":
+        "13.4", "revised": "2018-08-31T18:02:59Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "typo errata 6772", "version":
+        "13.3", "revised": "2018-08-31T15:08:42Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "deleted numbering from glossary
+        equations", "version": "13.2", "revised": "2018-08-29T16:05:08Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Removed
+        all font size styling. -MJ", "version": "13.1", "revised": "2018-08-06T20:14:13Z",
+        "publisher": {"surname": "OpenStax College", "suffix": "", "firstname": "",
+        "title": "", "fullname": "OpenStax", "id": "OpenStaxCollege"}}, {"changes":
+        "Removed mathsize variations throughout text. -MJ", "version": "12.1", "revised":
+        "2018-08-03T20:49:52Z", "publisher": {"surname": "OpenStax College", "suffix":
+        "", "firstname": "", "title": "", "fullname": "OpenStax", "id": "OpenStaxCollege"}},
+        {"changes": "Errata# 6530 -MJ ", "version": "11.42", "revised": "2018-08-03T16:58:27Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated figure credit je", "version": "11.41", "revised": "2018-08-03T16:02:43Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated figure credit je", "version": "11.40", "revised": "2018-08-03T15:54:57Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated figure credit je", "version": "11.39", "revised": "2018-08-03T15:49:04Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated figure credit je", "version": "11.38", "revised": "2018-08-03T15:37:50Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Errata# 6495 -MJ", "version": "11.37", "revised": "2018-07-27T19:46:15Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Errata# 6493 -MJ", "version": "11.36", "revised": "2018-07-27T19:11:11Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "errata 3984", "version": "11.35", "revised": "2018-07-16T15:27:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "art update",
+        "version": "11.34", "revised": "2018-07-13T17:16:22Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "caption change",
+        "version": "11.33", "revised": "2018-07-13T17:03:13Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "phet jar to html",
+        "version": "11.32", "revised": "2018-07-09T18:53:50Z", "publisher": {"surname":
+        "Stickney", "suffix": "", "firstname": "Ryan", "title": "", "fullname": "Ryan
+        Stickney", "id": "sanura"}}, {"changes": "diverse art", "version": "11.31",
+        "revised": "2018-07-09T16:44:55Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.30", "revised":
+        "2018-07-09T16:33:04Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.29", "revised":
+        "2018-07-09T16:25:02Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.28", "revised":
+        "2018-07-09T16:00:20Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.27", "revised":
+        "2018-07-09T15:43:10Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.26", "revised":
+        "2018-07-09T15:30:07Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.25", "revised":
+        "2018-07-09T15:14:01Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.24", "revised":
+        "2018-07-09T15:03:11Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.23", "revised":
+        "2018-07-09T14:57:28Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.22", "revised":
+        "2018-07-09T14:49:41Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.21", "revised":
+        "2018-07-09T14:43:16Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.20", "revised":
+        "2018-07-06T16:42:51Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.19", "revised":
+        "2018-07-06T16:34:02Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.18", "revised":
+        "2018-07-06T16:25:40Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.17", "revised":
+        "2018-07-06T16:19:00Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.16", "revised":
+        "2018-07-06T16:10:49Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.15", "revised":
+        "2018-07-06T16:03:22Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "updated Figure 04_01_01", "version": "11.14",
+        "revised": "2018-07-06T15:36:46Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.13", "revised":
+        "2018-07-06T15:21:04Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.12", "revised":
+        "2018-07-06T15:04:47Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.11", "revised":
+        "2018-07-06T14:59:51Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "diverse art", "version": "11.10", "revised":
+        "2018-07-06T14:48:10Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.9", "revised":
+        "2018-07-06T14:45:07Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited gender", "version": "11.8", "revised":
+        "2018-07-06T14:16:17Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.7", "revised":
+        "2018-07-05T21:44:13Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.6", "revised":
+        "2018-07-05T20:36:12Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.5", "revised":
+        "2018-07-05T20:25:11Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.4", "revised":
+        "2018-07-05T20:19:55Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.3", "revised":
+        "2018-07-05T20:13:52Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "edited skin color", "version": "11.2", "revised":
+        "2018-07-05T19:55:14Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "updated summary to match openstax", "version":
+        "11.1", "revised": "2018-06-25T18:24:04Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "embedded phet simulation", "version":
+        "10.63", "revised": "2018-06-21T21:05:04Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "embedded simulation", "version":
+        "10.62", "revised": "2018-06-21T20:57:28Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "embedded phet simulation", "version":
+        "10.61", "revised": "2018-06-21T20:43:31Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "embedded phet simulation", "version":
+        "10.60", "revised": "2018-06-21T20:21:17Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "embedded phet simulation into
+        module", "version": "10.59", "revised": "2018-06-21T19:13:21Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.58", "revised": "2018-06-21T19:02:46Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.57", "revised": "2018-06-21T18:54:02Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.56", "revised": "2018-06-21T18:45:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.55", "revised": "2018-06-21T18:38:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.54", "revised": "2018-06-21T18:32:54Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.53", "revised": "2018-06-21T18:13:43Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.52", "revised": "2018-06-21T18:03:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.51", "revised": "2018-06-21T17:22:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.50", "revised": "2018-06-21T16:48:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.49", "revised": "2018-06-21T16:31:04Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.48", "revised": "2018-06-21T16:24:07Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.47", "revised": "2018-06-21T16:14:02Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.46", "revised": "2018-06-20T18:56:44Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "phet
+        media updated", "version": "10.45", "revised": "2018-06-20T18:22:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.44", "revised": "2018-06-20T18:09:19Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "upated
+        phet simulation", "version": "10.43", "revised": "2018-06-20T16:16:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.42", "revised": "2018-06-20T15:35:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim\r\n", "version": "10.41", "revised": "2018-06-20T15:33:36Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet simulation", "version": "10.40", "revised": "2018-06-20T15:18:18Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.39", "revised": "2018-06-20T15:15:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.38", "revised": "2018-06-20T14:53:22Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.37", "revised": "2018-06-20T14:44:30Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "PhET
+        simulation add interactive class to note", "version": "10.36", "revised":
+        "2018-06-20T14:23:02Z", "publisher": {"surname": "Physics", "suffix": "",
+        "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "added \"interactive\" class to note", "version":
+        "10.35", "revised": "2018-06-20T14:14:08Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "embedded PhET simulation", "version":
+        "10.34", "revised": "2018-06-20T13:56:22Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "PhET simulation embedded", "version":
+        "10.33", "revised": "2018-06-20T13:49:33Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "PhET simulation embedded", "version":
+        "10.32", "revised": "2018-06-20T13:41:26Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "PhET simulation - embedded", "version":
+        "10.31", "revised": "2018-06-20T13:32:49Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "PhET simulation embedded", "version":
+        "10.30", "revised": "2018-06-20T13:29:27Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "updated phet media to be embedded
+        in module", "version": "10.29", "revised": "2018-06-19T21:56:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        phet sim", "version": "10.28", "revised": "2018-06-19T21:35:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "phet
+        simulation - link to embed", "version": "10.27", "revised": "2018-06-19T21:28:29Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated phet interactive media to be embedded in module", "version": "10.26",
+        "revised": "2018-06-19T21:26:09Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "updated phet interactive media", "version":
+        "10.25", "revised": "2018-06-19T20:22:34Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "Gravity and Orbits simulation
+        - link to embed", "version": "10.24", "revised": "2018-06-19T20:13:19Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Ladybug
+        Motion 2D - link to embed", "version": "10.23", "revised": "2018-06-19T20:04:05Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated phet sim", "version": "10.22", "revised": "2018-06-19T20:01:55Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "added PhET simulation", "version": "10.21", "revised": "2018-06-19T19:51:10Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated phet sim\r\n", "version": "10.20", "revised": "2018-06-19T19:50:22Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated phet interactive media", "version": "10.19", "revised": "2018-06-19T19:47:21Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated phet sim", "version": "10.18", "revised": "2018-06-19T19:38:38Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "changed name of simulation (in description) from \"Ladybug Motion 2D\" to
+        \"Motion in 2D\"", "version": "10.17", "revised": "2018-06-19T19:25:00Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "updated phet sim", "version": "10.16", "revised": "2018-06-19T19:11:13Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Gravity force lab - link to embed", "version": "10.15", "revised": "2018-06-19T19:07:06Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Projectile motion link to embed", "version": "10.14", "revised": "2018-06-19T18:45:33Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Vector addition - link to embed", "version": "10.13", "revised": "2018-06-19T18:38:42Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Updated interactive phet figure", "version": "10.12", "revised": "2018-06-19T18:31:40Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Vector addition simulation replace link with embed", "version": "10.11",
+        "revised": "2018-06-19T17:22:20Z", "publisher": {"surname": "Physics", "suffix":
+        "", "firstname": "College", "title": "", "fullname": "OSC Physics Maintainer",
+        "id": "cnxcap"}}, {"changes": "Maze Game replace link with embedded", "version":
+        "10.10", "revised": "2018-06-19T17:10:04Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "updated phet sim", "version":
+        "10.9", "revised": "2018-06-19T17:02:01Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "Ladybug motion - replace link
+        with embed", "version": "10.8", "revised": "2018-06-19T16:56:28Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Equation
+        Grapher simulation - replaced jar file with embedded web page", "version":
+        "10.7", "revised": "2018-06-19T16:45:25Z", "publisher": {"surname": "Physics",
+        "suffix": "", "firstname": "College", "title": "", "fullname": "OSC Physics
+        Maintainer", "id": "cnxcap"}}, {"changes": "Embedded moving man simulation",
+        "version": "10.6", "revised": "2018-06-19T16:33:32Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated phet sim",
+        "version": "10.5", "revised": "2018-06-19T16:21:15Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Replace Estimation
+        simulation jar file with embedded media", "version": "10.4", "revised": "2018-06-19T16:15:02Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "embed Phet simulation", "version": "10.3", "revised": "2018-06-19T15:54:46Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "1.1 replace jar with web link", "version": "10.2", "revised": "2018-06-19T14:43:02Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "New GA code", "version": "10.1", "revised": "2018-04-11T17:30:20Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "errata
+        id 3664", "version": "9.103", "revised": "2018-04-02T22:51:04Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "errata
+        #4345", "version": "9.102", "revised": "2018-04-02T22:13:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "errata
+        #4770", "version": "9.101", "revised": "2018-04-02T22:07:54Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "errata
+        #4791", "version": "9.100", "revised": "2018-04-02T21:52:29Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "errata
+        4312", "version": "9.99", "revised": "2018-02-28T14:54:05Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Corrected
+        typo in Chapter 13.4.\r\n-MJ", "version": "9.98", "revised": "2017-12-19T18:44:41Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Corrected typo in Chapter 9.2.\r\n-MJ", "version": "9.97", "revised": "2017-12-19T18:39:44Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Corrected typo in Chapter 07\r\n-MJ", "version": "9.96", "revised": "2017-12-19T18:33:07Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Added Preface", "version": "9.95", "revised": "2017-09-27T17:00:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.94", "revised": "2017-08-22T20:04:58Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.93", "revised": "2017-08-01T20:41:00Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.92", "revised": "2017-08-01T20:31:04Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.91", "revised": "2017-08-01T18:57:21Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.90", "revised": "2017-08-01T18:20:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.89", "revised": "2017-08-01T17:04:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.88", "revised": "2017-08-01T16:02:14Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.87", "revised": "2017-08-01T15:11:55Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.86", "revised": "2017-07-27T16:52:28Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.85", "revised": "2017-07-24T21:42:57Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.84", "revised": "2017-07-24T21:36:13Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.83", "revised": "2017-07-24T21:21:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.82", "revised": "2017-07-24T20:45:04Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.81", "revised": "2017-07-21T17:21:43Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.80", "revised": "2017-07-21T16:42:48Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.79", "revised": "2017-07-21T16:23:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.78", "revised": "2017-06-13T18:43:08Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.77", "revised": "2017-05-19T16:53:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.76", "revised": "2017-05-19T16:14:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.75", "revised": "2017-05-19T15:48:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.74", "revised": "2017-04-04T18:55:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.73", "revised": "2017-02-22T22:56:49Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.72", "revised": "2017-02-10T20:18:06Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.71", "revised": "2017-02-10T20:13:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.70", "revised": "2017-02-10T20:10:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.69", "revised": "2017-02-10T20:06:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.68", "revised": "2017-02-10T20:05:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.67", "revised": "2017-02-10T20:02:12Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.66", "revised": "2017-02-10T20:01:12Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.65", "revised": "2017-02-10T19:57:37Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.64", "revised": "2017-02-10T18:07:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.63", "revised": "2017-02-10T18:01:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.62", "revised": "2017-02-10T18:00:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.61", "revised": "2017-02-10T17:58:30Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.60", "revised": "2017-02-10T17:55:53Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.59", "revised": "2017-02-10T17:53:35Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.58", "revised": "2017-01-13T23:06:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.57", "revised": "2017-01-13T22:49:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.56", "revised": "2017-01-13T22:42:06Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.55", "revised": "2017-01-13T22:31:43Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.54", "revised": "2017-01-13T20:57:59Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.53", "revised": "2016-12-19T17:33:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.52", "revised": "2016-12-19T17:15:21Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.51", "revised": "2016-12-19T16:53:45Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.50", "revised": "2016-12-19T16:23:01Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.49", "revised": "2016-12-19T16:12:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.48", "revised": "2016-12-19T16:07:42Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.47", "revised": "2016-12-16T19:00:55Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.46", "revised": "2016-12-06T20:26:20Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.45", "revised": "2016-12-06T20:23:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.44", "revised": "2016-12-06T20:20:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.43", "revised": "2016-12-06T20:12:16Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.42", "revised": "2016-12-06T20:05:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.41", "revised": "2016-12-06T20:00:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.40", "revised": "2016-12-06T19:47:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.39", "revised": "2016-11-04T21:50:44Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.38", "revised": "2016-09-28T21:57:46Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.37", "revised": "2016-09-17T21:07:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.36", "revised": "2016-09-17T19:45:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.35", "revised": "2016-08-22T21:02:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.34", "revised": "2016-08-22T20:43:00Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.33", "revised": "2016-05-18T17:17:57Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.32", "revised": "2016-05-18T14:33:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.31", "revised": "2016-04-21T18:35:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.30", "revised": "2016-02-25T22:38:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.29", "revised": "2016-02-25T22:34:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.28", "revised": "2016-02-25T22:10:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.27", "revised": "2016-02-25T22:07:35Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.26", "revised": "2016-02-25T22:03:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.25", "revised": "2016-02-25T21:39:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.24", "revised": "2016-02-25T21:29:14Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.23", "revised": "2016-02-25T21:23:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.22", "revised": "2016-02-25T21:20:13Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.21", "revised": "2016-02-25T21:13:02Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.20", "revised": "2016-02-25T21:03:54Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.19", "revised": "2016-02-25T20:53:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.18", "revised": "2016-02-25T20:47:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.17", "revised": "2016-02-25T19:57:06Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.16", "revised": "2016-02-25T19:42:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.15", "revised": "2016-02-25T19:22:55Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.14", "revised": "2016-02-25T18:26:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.13", "revised": "2016-02-25T18:17:36Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.12", "revised": "2016-02-25T18:09:47Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.11", "revised": "2016-02-25T17:28:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.10", "revised": "2016-02-25T17:13:36Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.9", "revised": "2016-02-25T16:58:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.8", "revised": "2016-02-25T16:57:28Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.7", "revised": "2016-02-25T16:48:08Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.6", "revised": "2016-02-25T16:32:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.5", "revised": "2016-02-25T16:26:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.4", "revised": "2015-09-29T20:25:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.3", "revised": "2015-09-29T20:21:35Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.2", "revised": "2015-09-29T20:04:14Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Added
+        Preface", "version": "9.1", "revised": "2015-07-27T17:55:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.47", "revised": "2015-07-08T15:30:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.46", "revised": "2015-07-01T13:39:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.45", "revised": "2015-06-29T18:30:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.44", "revised": "2015-06-29T17:20:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.43", "revised": "2015-06-26T19:05:54Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.42", "revised": "2015-06-26T18:34:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.41", "revised": "2015-05-14T19:42:02Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.40", "revised": "2015-05-14T19:09:58Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.39", "revised": "2015-05-13T19:11:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.38", "revised": "2015-05-13T18:51:23Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.37", "revised": "2015-05-13T18:40:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.36", "revised": "2015-05-13T17:35:30Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.35", "revised": "2015-05-13T16:27:05Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.34", "revised": "2015-03-02T16:40:51Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.33", "revised": "2015-02-03T15:05:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.32", "revised": "2014-12-10T22:41:36Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.31", "revised": "2014-12-10T21:03:02Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.30", "revised": "2014-12-10T20:47:23Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.29", "revised": "2014-11-19T19:33:17Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.28", "revised": "2014-11-10T23:02:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.27", "revised": "2014-11-10T22:37:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.26", "revised": "2014-11-10T22:29:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.25", "revised": "2014-11-10T22:22:48Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.24", "revised": "2014-11-10T22:18:07Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.23", "revised": "2014-11-10T21:49:23Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.22", "revised": "2014-11-10T21:45:29Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.21", "revised": "2014-11-10T21:38:04Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.20", "revised": "2014-10-28T17:55:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.19", "revised": "2014-10-28T17:38:26Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.18", "revised": "2014-10-28T16:59:35Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.17", "revised": "2014-10-28T16:44:17Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.16", "revised": "2014-10-28T16:35:36Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.15", "revised": "2014-10-28T16:25:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.14", "revised": "2014-10-28T16:06:23Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.13", "revised": "2014-10-28T15:56:37Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.12", "revised": "2014-10-28T15:18:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.11", "revised": "2014-10-27T20:40:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.10", "revised": "2014-10-27T20:24:40Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.9", "revised": "2014-09-17T14:21:18Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.8", "revised": "2014-08-18T21:12:59Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.7", "revised": "2014-08-04T14:44:05Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.6", "revised": "2014-07-30T19:50:30Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.5", "revised": "2014-07-15T16:02:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.4", "revised": "2014-07-15T15:51:28Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.3", "revised": "2014-07-14T21:52:48Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.2", "revised": "2014-07-09T19:38:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "changed
+        chapter title", "version": "8.1", "revised": "2014-03-07T15:53:45Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.61", "revised": "2014-02-24T21:03:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.60", "revised": "2014-02-24T20:41:34Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.59", "revised": "2014-02-20T16:58:59Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.58", "revised": "2014-02-20T16:52:32Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.57", "revised": "2014-02-20T15:54:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.56", "revised": "2014-02-20T15:35:35Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.55", "revised": "2014-02-20T15:18:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.54", "revised": "2014-02-20T15:07:43Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.53", "revised": "2014-02-20T14:44:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.52", "revised": "2014-02-19T22:42:20Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.51", "revised": "2014-02-19T22:35:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.50", "revised": "2014-02-19T21:37:21Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.49", "revised": "2014-02-19T21:15:04Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.48", "revised": "2014-02-19T19:45:00Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.47", "revised": "2014-02-19T18:59:02Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.46", "revised": "2014-02-19T17:54:21Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.45", "revised": "2014-02-19T17:40:50Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.44", "revised": "2014-02-19T17:36:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.43", "revised": "2014-02-19T17:24:45Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.42", "revised": "2014-02-19T16:46:20Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.41", "revised": "2014-02-19T16:37:23Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.40", "revised": "2014-02-19T16:30:27Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.39", "revised": "2014-02-19T15:26:05Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.38", "revised": "2014-02-18T21:18:01Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.37", "revised": "2014-02-18T20:49:38Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.36", "revised": "2014-02-18T20:31:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.35", "revised": "2014-02-18T20:26:41Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.34", "revised": "2014-02-18T20:12:24Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.33", "revised": "2014-02-18T18:59:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.32", "revised": "2014-02-18T18:23:23Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.31", "revised": "2013-10-21T20:53:09Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.30", "revised": "2013-09-12T21:08:13Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.29", "revised": "2013-09-11T17:05:54Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.28", "revised": "2013-09-09T21:08:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.27", "revised": "2013-09-06T21:06:51Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.26", "revised": "2013-08-30T16:39:57Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.25", "revised": "2013-08-28T21:51:58Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.24", "revised": "2013-08-16T21:04:51Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.23", "revised": "2013-08-15T20:49:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.22", "revised": "2013-08-14T16:38:12Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.21", "revised": "2013-06-13T15:03:33Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.20", "revised": "2013-05-16T20:28:18Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.19", "revised": "2013-02-12T16:40:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.18", "revised": "2012-11-05T16:34:31Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.17", "revised": "2012-10-15T20:34:15Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.16", "revised": "2012-10-08T21:03:56Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.15", "revised": "2012-10-03T21:03:46Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.14", "revised": "2012-09-04T21:24:03Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.13", "revised": "2012-07-31T21:22:29Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.12", "revised": "2012-07-26T19:53:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.11", "revised": "2012-07-24T21:31:52Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.10", "revised": "2012-07-23T16:06:06Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.9", "revised": "2012-07-19T20:10:17Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.8", "revised": "2012-07-17T14:41:13Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.7", "revised": "2012-07-11T00:36:26Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.6", "revised": "2012-07-06T02:59:37Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.5", "revised": "2012-06-25T19:52:57Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.4", "revised": "2012-06-21T22:04:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.3", "revised": "2012-06-20T21:41:57Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.2", "revised": "2012-06-13T21:27:29Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "structure
+        update", "version": "7.1", "revised": "2012-06-12T21:12:05Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "restructured
+        appendix items", "version": "6.1", "revised": "2012-05-15T05:26:11Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "added
+        preface", "version": "5.1", "revised": "2012-03-30T22:07:10Z", "publisher":
+        {"surname": "Physics", "suffix": "", "firstname": "College", "title": "",
+        "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "updated
+        metadata and roles", "version": "4.1", "revised": "2012-03-29T15:31:53Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Added proper module.", "version": "3.1", "revised": "2012-01-26T18:05:27Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "removed module by incorrect author.", "version": "2.1", "revised": "2012-01-26T15:29:18Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes":
+        "Initial Publication", "version": "1.1", "revised": "2012-01-26T15:06:36Z",
+        "publisher": {"surname": "Physics", "suffix": "", "firstname": "College",
+        "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}}]}'
+    http_version: 
+  recorded_at: Tue, 09 Apr 2019 21:51:04 GMT
+- request:
+    method: get
+    uri: https://archive.cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a@14.79:1d1fd537-77fb-4eac-8a8a-60bbaa747b6d@5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - text/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin,dnt,accept-encoding,accept-language,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=31536000, public
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Apr 2019 21:59:50 GMT
+      Etag:
+      - '"3wgEyP9RbaeB1PMy0NVr7w"'
+      Expires:
+      - Tue, 07 Apr 2020 21:59:50 GMT
+      Link:
+      - <https://cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a:1d1fd537-77fb-4eac-8a8a-60bbaa747b6d/Introduction-to-Science-and-the-Realm-of-Physics,-Physical-Quantities,-and-Units>
+        ;rel="Canonical"
+      Server:
+      - waitress
+      X-Varnish-Status:
+      - cacheable - Cache-Control in backend response
+      X-Varnish-Backend:
+      - prod07_archive5
+      X-Varnish-Ttl:
+      - '31536000.000'
+      X-Varnish:
+      - 3788546 656965
+      Age:
+      - '85875'
+      Via:
+      - 1.1 varnish-v4
+      X-Varnish-Cache:
+      - HIT
+      Accept-Ranges:
+      - bytes
+      Transfer-Encoding:
+      - chunked
+      Strict-Transport-Security:
+      - max-age=16000000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"googleAnalytics": ["UA-30227798-1"], "version": "5", "submitlog":
+        "Removed all font size styling. -MJ", "abstract": "<div xmlns=\"http://www.w3.org/1999/xhtml\"
+        xmlns:c=\"http://cnx.rice.edu/cnxml\" xmlns:md=\"http://cnx.rice.edu/mdml\"
+        xmlns:qml=\"http://cnx.rice.edu/qml/1.0\" xmlns:mod=\"http://cnx.rice.edu/#moduleIds\"
+        xmlns:bib=\"http://bibtexml.sf.net/\" xmlns:data=\"http://dev.w3.org/html5/spec/#custom\"/>",
+        "revised": "2018-08-06T20:14:13Z", "printStyle": null, "roles": null, "keywords":
+        ["Relativity", "Units", "Approximation", "Law", "Meter", "Physics", "Theory",
+        "Model", "SI units", "Second", "Scientific method", "Quantum mechanics", "Physical
+        quantity", "Order of magnitude", "Modern physics", "Metric system", "Kilogram",
+        "Fundamental units", "English units", "Derived units", "Customary system",
+        "Conversion factor", "Classical physics", "Uncertainty", "Significant figures",
+        "Precision", "Percent uncertainty", "Accuracy"], "id": "1d1fd537-77fb-4eac-8a8a-60bbaa747b6d",
+        "canonical": "031da8d3-b525-429c-80cf-6c8ed997733a", "title": "Introduction
+        to Science and the Realm of Physics, Physical Quantities, and Units", "mediaType":
+        "application/vnd.org.cnx.module", "canon_url": "https://cnx.org/contents/031da8d3-b525-429c-80cf-6c8ed997733a:1d1fd537-77fb-4eac-8a8a-60bbaa747b6d/Introduction-to-Science-and-the-Realm-of-Physics,-Physical-Quantities,-and-Units",
+        "content": "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n  <body><div class=\"introduction\"
+        data-cnxml-to-html-ver=\"1.3.3\" data-type=\"page\" id=\"1d1fd537-77fb-4eac-8a8a-60bbaa747b6d\"><div
+        class=\"os-chapter-outline\"><h3 class=\"os-title\">Chapter Outline</h3><div
+        class=\"os-chapter-objective\"><a class=\"os-chapter-objective\" href=\"/contents/39256206-03b0-4396-abb6-75e6ee5e3c7b#88478\"><span
+        class=\"os-number\">1.1</span><span class=\"os-divider\"> </span><span class=\"os-text\">Physics:
+        An Introduction</span></a><div class=\"learning-objective\"><div data-type=\"abstract\"
+        id=\"912\"><ul>\n<li>Explain the difference between a principle and a law.\n</li><li>Explain
+        the difference between a model and a theory.</li>\n</ul></div></div></div><div
+        class=\"os-chapter-objective\"><a class=\"os-chapter-objective\" href=\"/contents/102e9604-daa7-4a09-9f9e-232251d1a4ee#26740\"><span
+        class=\"os-number\">1.2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Physical
+        Quantities and Units</span></a><div class=\"learning-objective\"><div data-type=\"abstract\"
+        id=\"40046\"><ul>\n<li>Perform unit conversions both in the SI and English
+        units.\n</li>\n<li>Explain the most common prefixes in the SI units and be
+        able to write them in scientific notation.</li>\n</ul></div></div></div><div
+        class=\"os-chapter-objective\"><a class=\"os-chapter-objective\" href=\"/contents/4bba6a1c-a0e6-45c0-988c-0d5c23425670#37343\"><span
+        class=\"os-number\">1.3</span><span class=\"os-divider\"> </span><span class=\"os-text\">Accuracy,
+        Precision, and Significant Figures</span></a><div class=\"learning-objective\"><div
+        data-type=\"abstract\" id=\"98956\"><ul>\n<li>Determine the appropriate number
+        of significant figures in both addition and subtraction, as well as multiplication
+        and division calculations.\n</li>\n<li>Calculate the percent uncertainty of
+        a measurement.</li>\n</ul></div></div></div><div class=\"os-chapter-objective\"><a
+        class=\"os-chapter-objective\" href=\"/contents/eb75b532-91ca-4c3d-b803-db329981914a#45926\"><span
+        class=\"os-number\">1.4</span><span class=\"os-divider\"> </span><span class=\"os-text\">Approximation</span></a><div
+        class=\"learning-objective\"><div data-type=\"abstract\" id=\"19219\"><ul>\n<li>Make
+        reasonable approximations based on given data.</li>\n</ul></div></div></div></div><h2
+        data-type=\"document-title\" id=\"34096\"><span class=\"os-text\">Introduction
+        to Science and the Realm of Physics, Physical Quantities, and Units</span></h2>\n\n\n\n\n\n\n\n
+        \n \n\n\n    \n\n    <div class=\"os-figure\"><figure class=\"splash\" id=\"import-auto-id2688158\"><span
+        data-alt=\"The spiral galaxy Andromeda is shown.\" data-type=\"media\" id=\"import-auto-id3147051\"><img
+        alt=\"The spiral galaxy Andromeda is shown.\" data-media-type=\"image/jpg\"
+        id=\"1513\" src=\"/resources/d47864c2ac77d80b1f2ff4c4c7f1b2059669e3e9\"/></span>\n\t</figure><div
+        class=\"os-caption-container\"><span class=\"os-title-label\">Figure </span><span
+        class=\"os-number\">1.1</span><span class=\"os-divider\"> </span><span class=\"os-caption\">Galaxies
+        are as immense as atoms are small. Yet the same laws of physics describe both,
+        and all the rest of nature\u2014an indication of the underlying unity in the
+        universe. The laws of physics are surprisingly few in number, implying an
+        underlying simplicity to nature\u2019s apparent complexity. (credit: NASA,
+        JPL-Caltech, P. Barmby, Harvard-Smithsonian Center for Astrophysics)</span></div></div><p
+        id=\"import-auto-id2747641\">What is your first reaction when you hear the
+        word \u201cphysics\u201d? Did you imagine working through difficult equations
+        or memorizing formulas that seem to have no real use in life outside the physics
+        classroom? Many people come to the subject of physics with a bit of fear.
+        But as you begin your exploration of this broad-ranging subject, you may soon
+        come to realize that physics plays a much larger role in your life than you
+        first thought, no matter your life goals or career choice.</p><p id=\"import-auto-id1349762\">For
+        example, take a look at the image above. This image is of the Andromeda Galaxy,
+        which contains billions of individual stars, huge clouds of gas, and dust.
+        Two smaller galaxies are also visible as bright blue spots in the background.
+        At a staggering 2.5 million light years from the Earth, this galaxy is the
+        nearest one to our own galaxy (which is called the Milky Way). The stars and
+        planets that make up Andromeda might seem to be the furthest thing from most
+        people\u2019s regular, everyday lives. But Andromeda is a great starting point
+        to think about the forces that hold together the universe. The forces that
+        cause Andromeda to act as it does are the same forces we contend with here
+        on Earth, whether we are planning to send a rocket into space or simply raise
+        the walls for a new home. The same gravity that causes the stars of Andromeda
+        to rotate and revolve also causes water to flow over hydroelectric dams here
+        on Earth. Tonight, take a moment to look up at the stars. The forces out there
+        are the same as the ones here on Earth. Through a study of physics, you may
+        gain a greater understanding of the interconnectedness of everything we can
+        see and know in this universe.</p><p id=\"import-auto-id1665197\">Think now
+        about all of the technological devices that you use on a regular basis. Computers,
+        smart phones, GPS systems, MP3 players, and satellite radio might come to
+        mind. Next, think about the most exciting modern technologies that you have
+        heard about in the news, such as trains that levitate above tracks, \u201cinvisibility
+        cloaks\u201d that bend light around them, and microscopic robots that fight
+        cancer cells in our bodies. All of these groundbreaking advancements, commonplace
+        or unbelievable, rely on the principles of physics. Aside from playing a significant
+        role in technology, professionals such as engineers, pilots, physicians, physical
+        therapists, electricians, and computer programmers apply physics concepts
+        in their daily work. For example, a pilot must understand how wind forces
+        affect a flight path and a physical therapist must understand how the muscles
+        in the body experience forces as they move and bend. As you will learn in
+        this text, physics principles are propelling new, exciting technologies, and
+        these principles are applied in a wide range of careers.</p>\n    \n    <p
+        id=\"fs-id2195793\">In this text, you will begin to explore the history of
+        the formal study of physics, beginning with natural philosophy and the ancient
+        Greeks, and leading up through a review of Sir Isaac Newton and the laws of
+        physics that bear his name. You will also be introduced to the standards scientists
+        use when they study physical quantities and the interrelated system of measurements
+        most of the scientific community uses to communicate in a single mathematical
+        language. Finally, you will study the limits of our ability to be accurate
+        and precise, and the reasons scientists go to painstaking lengths to be as
+        clear as possible regarding their own limitations.</p>\n    \n    \n  </div></body>\n</html>\n",
+        "subjects": ["Mathematics and Statistics"], "legacy_id": "m42119", "parentId":
+        null, "resources": [{"media_type": "text/xml", "id": "5d946aed789ea1db8c8ed41bdd49c2d2f59cdc2e",
+        "filename": "index.cnxml"}, {"media_type": "text/xml", "id": "994ffa8e8516f2bb2ec65ddf394e941ca75abdf5",
+        "filename": "index.cnxml.html"}, {"media_type": "image/jpeg", "id": "d47864c2ac77d80b1f2ff4c4c7f1b2059669e3e9",
+        "filename": "Figure_01_00_01.jpg"}, {"media_type": "image/jpeg", "id": "eee8d075029add60f3155a942b35e1c9fd9f3cfa",
+        "filename": "Figure_01_00_01a.jpg"}], "publishers": [{"surname": "OpenStax
+        College", "suffix": "", "firstname": "", "title": "", "fullname": "OpenStax",
+        "id": "OpenStaxCollege"}, {"surname": "Physics", "suffix": "", "firstname":
+        "College", "title": "", "fullname": "OSC Physics Maintainer", "id": "cnxcap"}],
+        "parent": {"authors": [], "shortId": null, "version": "", "id": null, "title":
+        null}, "stateid": 1, "parentTitle": null, "shortId": "HR_VN3f7", "authors":
+        [{"surname": "OpenStax College", "suffix": "", "firstname": "", "title": "",
+        "fullname": "OpenStax", "id": "OpenStaxCollege"}], "parentVersion": "", "legacy_version":
+        "1.5", "licensors": [{"surname": "University", "suffix": "", "firstname":
+        "Rice", "title": "", "fullname": "Rice University", "id": "OSCRiceUniversity"}],
+        "language": "en", "license": {"url": "http://creativecommons.org/licenses/by/3.0/",
+        "code": "by", "version": "3.0", "name": "Creative Commons Attribution License"},
+        "created": "2011-12-28T17:41:38Z", "doctype": "", "buyLink": null, "submitter":
+        {"surname": "OpenStax College", "suffix": "", "firstname": "", "title": "",
+        "fullname": "OpenStax", "id": "OpenStaxCollege"}, "baked": null, "parentAuthors":
+        [], "history": [{"changes": "Removed all font size styling. -MJ", "version":
+        "5", "revised": "2018-08-06T20:14:13Z", "publisher": {"surname": "OpenStax
+        College", "suffix": "", "firstname": "", "title": "", "fullname": "OpenStax",
+        "id": "OpenStaxCollege"}}, {"changes": "Removed mathsize variations throughout
+        text. -MJ", "version": "4", "revised": "2018-08-03T20:49:52Z", "publisher":
+        {"surname": "OpenStax College", "suffix": "", "firstname": "", "title": "",
+        "fullname": "OpenStax", "id": "OpenStaxCollege"}}, {"changes": "updated images",
+        "version": "3", "revised": "2012-07-06T01:00:59Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "initial content publication",
+        "version": "2", "revised": "2012-03-30T18:06:25Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}, {"changes": "Created module",
+        "version": "1", "revised": "2011-12-28T17:42:12Z", "publisher": {"surname":
+        "Physics", "suffix": "", "firstname": "College", "title": "", "fullname":
+        "OSC Physics Maintainer", "id": "cnxcap"}}]}'
+    http_version: 
+  recorded_at: Tue, 09 Apr 2019 21:51:05 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/openstax/cnx/v1/element_spec.rb
+++ b/spec/lib/openstax/cnx/v1/element_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'vcr_helper'
+
+RSpec.describe OpenStax::Cnx::V1::Element, type: :external, vcr: VCR_OPTS do
+
+  let(:cnx_book_id) { '031da8d3-b525-429c-80cf-6c8ed997733a' }
+
+  let(:desired_elements) {
+    [
+      OpenStax::Cnx::V1::Figure,
+      OpenStax::Cnx::V1::Paragraph
+    ]
+  }
+
+  subject(:elements) {
+    OpenStax::Cnx::V1::Book.new(id: cnx_book_id).
+      root_book_part.
+      pages[1].
+      elements(element_classes: desired_elements)
+  }
+
+  it "finds the given elements within the book" do
+    OpenStax::Cnx::V1.with_archive_url("https://archive.cnx.org/contents") do
+      expect(elements.count).to eq 5
+      expect(elements[0]).to be_instance_of(OpenStax::Cnx::V1::Figure)
+      expect(elements[1]).to be_instance_of(OpenStax::Cnx::V1::Paragraph)
+      expect(elements[2]).to be_instance_of(OpenStax::Cnx::V1::Paragraph)
+      expect(elements[3]).to be_instance_of(OpenStax::Cnx::V1::Paragraph)
+      expect(elements[4]).to be_instance_of(OpenStax::Cnx::V1::Paragraph)
+    end
+  end
+end

--- a/spec/lib/openstax/cnx/v1/figure_spec.rb
+++ b/spec/lib/openstax/cnx/v1/figure_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe OpenStax::Cnx::V1::Figure do
+
+  let(:html) do
+    <<-FIGURE
+    <html>
+      <div class="os-figure">
+          <figure class="splash" id="import-auto-id2688158">
+             <span data-alt="The spiral galaxy Andromeda is shown." data-type="media" id="import-auto-id3147051">
+               <img alt="The spiral galaxy Andromeda is shown." data-media-type="image/jpg" id="1513" src="/resources/d47864c2ac77d80b1f2ff4c4c7f1b2059669e3e9">
+             </span>
+	        </figure>
+          <div class="os-caption-container">
+            <span class="os-title-label">Figure </span>
+            <span class="os-number">1.1</span>
+            <span class="os-divider"> </span>
+            <span class="os-caption">Galaxies are as immense as atoms are small. Yet the same laws of physics describe both, and all the rest of nature—an indication of the underlying unity in the universe. The laws of physics are surprisingly few in number, implying an underlying simplicity to nature’s apparent complexity. (credit: NASA, JPL-Caltech, P. Barmby, Harvard-Smithsonian Center for Astrophysics)
+             </span>
+          </div>
+      </div>
+    </html>
+    FIGURE
+  end
+
+  let(:content_dom) { Nokogiri::HTML(html) }
+  let(:figure_match) { content_dom.xpath(described_class.matcher) }
+  let(:figure) { described_class.new(node: figure_match) }
+
+  describe ".matcher" do
+    it "finds the figure" do
+      expect(figure_match.count).to eq 1
+    end
+  end
+
+  describe ".matches?" do
+    it "finds the figure" do
+      expect(described_class.matches?(figure_match.first)).to be_truthy
+    end
+
+    it "should not find a paragraph in the figure node" do
+      expect(OpenStax::Cnx::V1::Paragraph.matches?(figure_match.first)).to_not be_truthy
+    end
+  end
+
+  describe "#caption" do
+    it "finds the figure caption" do
+      expect(figure.caption).to include 'Barmby'
+    end
+  end
+
+  describe "#alt_text" do
+    it "finds the figure alt_text" do
+      expect(figure.alt_text).to include 'Andromeda'
+    end
+  end
+end

--- a/spec/lib/openstax/cnx/v1/paragraph_spec.rb
+++ b/spec/lib/openstax/cnx/v1/paragraph_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe OpenStax::Cnx::V1::Paragraph do
+
+  let(:html) do
+    <<-FIGURE
+    <html>
+      <p id="import-auto-id2747641">What is your first reaction when you hear the word “physics”? Did you imagine working through difficult equations or memorizing formulas that seem to have no real use in life outside the physics classroom? Many people come to the subject of physics with a bit of fear. But as you begin your exploration of this broad-ranging subject, you may soon come to realize that physics plays a much larger role in your life than you first thought, no matter your life goals or career choice.
+      </p>
+    </html>
+    FIGURE
+  end
+
+  let(:content_dom) { Nokogiri::HTML(html) }
+  let(:paragraph_match) { content_dom.xpath(described_class.matcher) }
+  let(:figure) { described_class.new(node: paragraph_match) }
+
+  describe ".matcher" do
+    it "finds the paragraph" do
+      expect(paragraph_match.count).to eq 1
+    end
+  end
+
+  describe ".matches?" do
+    it "finds the paragraph" do
+      expect(described_class.matches?(paragraph_match.first)).to be_truthy
+    end
+
+    it "should not find a figure in the paragraph node" do
+      expect(OpenStax::Cnx::V1::Figure.matches?(paragraph_match.first)).to_not be_truthy
+    end
+  end
+
+  describe "#text" do
+    it "finds the paragraph text" do
+      expect(paragraph_match.text).to include 'subject of physics'
+    end
+  end
+end


### PR DESCRIPTION
@steveburkett it'd also be fine to add a "direct to pages" recursive routine in this gem like what is in open-search. 

```ruby
book = OpenStax::Cnx::V1.book(id: "031da8d3-b525-429c-80cf-6c8ed997733a")
pages = book.root_book_part.pages
pages.count # => 420
pages.map(&:class).uniq # => [OpenStax::Cnx::V1::Page]
pages.map{|page| page.baked_book_location.join(".")} # => ["", "", "1.1", "1.2", "1.3", "1.4", "", "", "", "", "", "2.1", "2.2", "2.3", "2.4", ...
```

Incidentally, one thing I forgot about is that there are lots of pages that are "special" -- see the pages in the example above which have a blank book location.  Here are two of those:

```ruby
pages[6].title # => "Glossary"
pages[7].title # => "Section Summary"
```

I can imagine that we'll want to decide whether to include or exclude those in our search indexes, and adding methods like `is_glossary?` and `is_section_summary?` to `Page` in this gem might be a good idea.