### PR TITLE
Add capture of ID to paragraph and figure elements

### DIFF
--- a/lib/openstax/cnx/v1/figure.rb
+++ b/lib/openstax/cnx/v1/figure.rb
@@ -4,6 +4,7 @@ module OpenStax::Cnx::V1
 
     MATCH_FIGURE_CAPTION = ".//*[contains(@class, 'os-caption')]"
     MATCH_FIGURE_ALT_TEXT = './/*[@data-alt]'
+    MATCH_FIGURE_ELEM = './/figure'
 
     def initialize(node:)
       super
@@ -11,6 +12,10 @@ module OpenStax::Cnx::V1
 
     def caption
       node.xpath(MATCH_FIGURE_CAPTION).first.try(:text)
+    end
+
+    def id
+      node.xpath(MATCH_FIGURE_ELEM).first.attr("id")
     end
 
     def alt_text

--- a/lib/openstax/cnx/v1/paragraph.rb
+++ b/lib/openstax/cnx/v1/paragraph.rb
@@ -10,6 +10,10 @@ module OpenStax::Cnx::V1
       node.text
     end
 
+    def id
+      node.attr('id').value
+    end
+
     def self.matcher
       MATCH_PARAGRAPH
     end

--- a/spec/lib/openstax/cnx/v1/figure_spec.rb
+++ b/spec/lib/openstax/cnx/v1/figure_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe OpenStax::Cnx::V1::Figure do
     end
   end
 
+  describe "#id" do
+    it "finds the figure id" do
+      expect(figure.id).to eq 'import-auto-id2688158'
+    end
+  end
+
   describe "#alt_text" do
     it "finds the figure alt_text" do
       expect(figure.alt_text).to include 'Andromeda'

--- a/spec/lib/openstax/cnx/v1/paragraph_spec.rb
+++ b/spec/lib/openstax/cnx/v1/paragraph_spec.rb
@@ -3,17 +3,17 @@ require 'spec_helper'
 RSpec.describe OpenStax::Cnx::V1::Paragraph do
 
   let(:html) do
-    <<-FIGURE
+    <<-PARAGRAPH
     <html>
       <p id="import-auto-id2747641">What is your first reaction when you hear the word “physics”? Did you imagine working through difficult equations or memorizing formulas that seem to have no real use in life outside the physics classroom? Many people come to the subject of physics with a bit of fear. But as you begin your exploration of this broad-ranging subject, you may soon come to realize that physics plays a much larger role in your life than you first thought, no matter your life goals or career choice.
       </p>
     </html>
-    FIGURE
+    PARAGRAPH
   end
 
   let(:content_dom) { Nokogiri::HTML(html) }
   let(:paragraph_match) { content_dom.xpath(described_class.matcher) }
-  let(:figure) { described_class.new(node: paragraph_match) }
+  let(:paragraph) { described_class.new(node: paragraph_match) }
 
   describe ".matcher" do
     it "finds the paragraph" do
@@ -34,6 +34,12 @@ RSpec.describe OpenStax::Cnx::V1::Paragraph do
   describe "#text" do
     it "finds the paragraph text" do
       expect(paragraph_match.text).to include 'subject of physics'
+    end
+  end
+
+  describe "#id" do
+    it "finds the paragraph id" do
+      expect(paragraph.id).to eq 'import-auto-id2747641'
     end
   end
 end


### PR DESCRIPTION
Capture the ID of the figure and paragraph elements when building the tree of page elements. 

1/2 of the fix for this issue

https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/298