### PR TITLE
Fix bug in paragraph ID

### DIFF
--- a/lib/openstax/cnx/v1/paragraph.rb
+++ b/lib/openstax/cnx/v1/paragraph.rb
@@ -11,7 +11,7 @@ module OpenStax::Cnx::V1
     end
 
     def id
-      node.attr('id').value
+      node.attr('id')
     end
 
     def self.matcher

--- a/spec/lib/openstax/cnx/v1/figure_spec.rb
+++ b/spec/lib/openstax/cnx/v1/figure_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe OpenStax::Cnx::V1::Figure do
   end
 
   let(:content_dom) { Nokogiri::HTML(html) }
-  let(:figure_match) { content_dom.xpath(described_class.matcher) }
+  let(:figure_match) { content_dom.xpath(described_class.matcher).first }
   let(:figure) { described_class.new(node: figure_match) }
 
   describe ".matcher" do
@@ -35,11 +35,11 @@ RSpec.describe OpenStax::Cnx::V1::Figure do
 
   describe ".matches?" do
     it "finds the figure" do
-      expect(described_class.matches?(figure_match.first)).to be_truthy
+      expect(described_class.matches?(figure_match)).to be_truthy
     end
 
     it "should not find a paragraph in the figure node" do
-      expect(OpenStax::Cnx::V1::Paragraph.matches?(figure_match.first)).to_not be_truthy
+      expect(OpenStax::Cnx::V1::Paragraph.matches?(figure_match)).to_not be_truthy
     end
   end
 

--- a/spec/lib/openstax/cnx/v1/paragraph_spec.rb
+++ b/spec/lib/openstax/cnx/v1/paragraph_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OpenStax::Cnx::V1::Paragraph do
   end
 
   let(:content_dom) { Nokogiri::HTML(html) }
-  let(:paragraph_match) { content_dom.xpath(described_class.matcher) }
+  let(:paragraph_match) { content_dom.xpath(described_class.matcher).first }
   let(:paragraph) { described_class.new(node: paragraph_match) }
 
   describe ".matcher" do
@@ -23,11 +23,11 @@ RSpec.describe OpenStax::Cnx::V1::Paragraph do
 
   describe ".matches?" do
     it "finds the paragraph" do
-      expect(described_class.matches?(paragraph_match.first)).to be_truthy
+      expect(described_class.matches?(paragraph_match)).to be_truthy
     end
 
     it "should not find a figure in the paragraph node" do
-      expect(OpenStax::Cnx::V1::Figure.matches?(paragraph_match.first)).to_not be_truthy
+      expect(OpenStax::Cnx::V1::Figure.matches?(paragraph_match)).to_not be_truthy
     end
   end
 


### PR DESCRIPTION
The node passed to Paragraph should be a XML::Element (the result of a .each). 

The tests were incorrect and needed to be fixed, as well as the code.

