### PR TITLE
"new" open-uri compatibility

### DIFF
--- a/lib/openstax/cnx/v1.rb
+++ b/lib/openstax/cnx/v1.rb
@@ -121,7 +121,7 @@ module OpenStax::Cnx::V1
     def fetch(url)
       begin
         OpenStax::Cnx::V1.logger.debug { "Fetching #{url}" }
-        data = JSON.parse open(url, 'ACCEPT' => 'text/json').read
+        data = JSON.parse URI.open(url, 'ACCEPT' => 'text/json').read
         data.delete("history") if configuration.ignore_history
         data
       rescue OpenURI::HTTPError => exception


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-657

Make this gem compatible with newer versions of open-uri, which no longer override Kernel.open